### PR TITLE
Login passport 관련 코드 수정 및 정리

### DIFF
--- a/server/src/config/index.js
+++ b/server/src/config/index.js
@@ -2,7 +2,7 @@ const dotenv = require('dotenv');
 
 const environment = process.env.NODE_ENV || 'development';
 dotenv.config({
-  path: `../${environment}.env`,
+  path: `${__dirname}/../../${environment}.env`,
 });
 
 module.exports = {

--- a/server/src/controllers/auth.js
+++ b/server/src/controllers/auth.js
@@ -2,15 +2,17 @@ const jwt = require('jsonwebtoken');
 const passport = require('passport');
 
 const githubAuth = async (req, res, next) => {
-  passport.authenticate('github', { session: false }, (err, snsId) => {
-    if (err || !snsId) {
-      return res.redirect('/auth');
+  passport.authenticate('github', { session: false }, (err, sns_id) => {
+    if (err || !sns_id) {
+      return res.json({ msg: 'GitHub 로그인 오류 발생' });
     }
-    const payload = { snsId, provider: 'github' };
+    const payload = { sns_id, provider: 'github' };
     const token = jwt.sign(payload, process.env.JWT_SECRET);
 
-    return res.json({ jwt: token });
+    return res.status(200).json({ jwt: token });
   })(req, res, next);
 };
 
-module.exports = { githubAuth };
+const logout = (req, res, next) => res.status(200).json({ msg: '로그아웃 성공' });
+
+module.exports = { githubAuth, logout };

--- a/server/src/loaders/index.js
+++ b/server/src/loaders/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const passport = require('passport');
 const morgan = require('morgan');
 const cookieParser = require('cookie-parser');
+const createError = require('http-errors');
 const passportConfig = require('../passport');
 const { sequelize } = require('../models');
 const authRouter = require('../routes/auth');
@@ -25,4 +26,13 @@ module.exports = (app) => {
   app.use(morgan('dev'));
   app.use(cookieParser());
   app.use('/auth', authRouter);
+
+  app.use((req, res, next) => {
+    next(createError(404));
+  });
+
+  app.use((err, req, res, next) => {
+    res.status(err.status || 500);
+    res.send(err.message);
+  });
 };

--- a/server/src/loaders/index.js
+++ b/server/src/loaders/index.js
@@ -3,6 +3,7 @@ const passport = require('passport');
 const morgan = require('morgan');
 const cookieParser = require('cookie-parser');
 const createError = require('http-errors');
+const cors = require('cors');
 const passportConfig = require('../passport');
 const { sequelize } = require('../models');
 const authRouter = require('../routes/auth');
@@ -25,6 +26,7 @@ module.exports = (app) => {
   app.use(express.urlencoded({ extended: false }));
   app.use(morgan('dev'));
   app.use(cookieParser());
+  app.use(cors());
   app.use('/auth', authRouter);
 
   app.use((req, res, next) => {

--- a/server/src/middlewares/auth.js
+++ b/server/src/middlewares/auth.js
@@ -1,13 +1,24 @@
 const passport = require('passport');
 
-const isAuthenticated = passport.authenticate('jwt', { session: false });
+const isAuth = (req, res, next) => {
+  passport.authenticate('jwt', { session: false }, (err, user, info) => {
+    if (err) return next(err);
 
-const isNotAuthenticated = (req, res, next) => {
-  if (req.headers.authorization) {
-    return res.json({ msg: '이미 로그인 된 상태입니다' });
-  }
+    if (info) {
+      const error = new Error(info.message);
+      error.status = 401; // 401 Unauthorized
+      return next(error);
+    }
 
-  return next();
+    if (!user) {
+      const error = new Error('Authentication failed');
+      error.status = 401;
+      return next(error);
+    }
+
+    req.user = user;
+    return next();
+  })(req, res, next);
 };
 
-module.exports = { isAuthenticated, isNotAuthenticated };
+module.exports = { isAuth };

--- a/server/src/passport/github-strategy.js
+++ b/server/src/passport/github-strategy.js
@@ -12,19 +12,19 @@ module.exports = () => {
         clientSecret: github.clientSecret,
         callbackURL: github.callbackURL,
       },
-      async (accessToken, refreshToken, profile, done) => {
+      async (accessToken, refreshToken, { username }, done) => {
         try {
           const exUser = await User.findOne({
-            where: { sns_id: profile.id, provider: 'github' },
+            where: { sns_id: username, provider: 'github' },
           });
           if (exUser) {
-            done(null, exUser);
+            done(null, exUser.sns_id);
           } else {
             const newUser = await User.create({
-              sns_id: profile.id,
-              provider: profile.provider,
+              sns_id: username,
+              provider: 'github',
             });
-            done(null, newUser);
+            done(null, newUser.sns_id);
           }
         } catch (err) {
           done(err);

--- a/server/src/passport/index.js
+++ b/server/src/passport/index.js
@@ -2,6 +2,7 @@ const github = require('./github-strategy');
 const jwt = require('./jwt-strategy');
 
 module.exports = () => {
+  // TODO: local-strategy 추가
   github();
   jwt();
 };

--- a/server/src/passport/jwt-strategy.js
+++ b/server/src/passport/jwt-strategy.js
@@ -1,7 +1,7 @@
 const passport = require('passport');
 const JwtStrategy = require('passport-jwt').Strategy;
 const { ExtractJwt } = require('passport-jwt');
-const User = require('../models/user');
+const { User } = require('../models');
 const config = require('../config');
 
 const opts = {};
@@ -12,24 +12,18 @@ module.exports = () => {
   passport.use(
     new JwtStrategy(opts, (jwtPayload, done) => {
       const findOption = {};
-      if (jwtPayload.snsId) {
+      if (jwtPayload.sns_id) {
         // github-login
-        findOption.sns_id = jwtPayload.snsId;
+        findOption.sns_id = jwtPayload.sns_id;
         findOption.provider = jwtPayload.provider;
       } else {
         // local-login
-        findOption.user_id = jwtPayload.userId;
+        findOption.user_id = jwtPayload.user_id;
       }
 
-      User.findOne(findOption, (err, user) => {
-        if (err) {
-          return done(err, false);
-        }
-        if (user) {
-          return done(null, user);
-        }
-        return done(null, false);
-      });
+      return User.findOne({ where: findOption })
+        .then((user) => done(null, user))
+        .catch((err) => done(err));
     }),
   );
 };

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -3,11 +3,14 @@ const passport = require('passport');
 
 const router = express.Router();
 const AuthController = require('../controllers/auth');
+const { isAuthenticated, isNotAuthenticated } = require('../middlewares/auth');
 
-router.get('/github/login', passport.authenticate('github'));
+/* 로그인 되지 않은 상태에서만 login 시도 가능 */
+router.get('/github/login', isNotAuthenticated, passport.authenticate('github'));
+
 router.get('/github/callback', AuthController.githubAuth);
 
-// TODO: logout을 위한 controller 작성 필요
-// router.get('/logout',);
+/* 로그인 된 상태에서만 logout 시도 가능 */
+router.get('/logout', isAuthenticated, AuthController.logout);
 
 module.exports = router;

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -3,14 +3,12 @@ const passport = require('passport');
 
 const router = express.Router();
 const AuthController = require('../controllers/auth');
-const { isAuthenticated, isNotAuthenticated } = require('../middlewares/auth');
+const { isAuth } = require('../middlewares/auth');
 
-/* 로그인 되지 않은 상태에서만 login 시도 가능 */
-router.get('/github/login', isNotAuthenticated, passport.authenticate('github'));
+router.get('/github/login', passport.authenticate('github'));
 
 router.get('/github/callback', AuthController.githubAuth);
 
-/* 로그인 된 상태에서만 logout 시도 가능 */
-router.get('/logout', isAuthenticated, AuthController.logout);
+router.get('/logout', isAuth, AuthController.logout);
 
 module.exports = router;


### PR DESCRIPTION
### 해당 이슈
사용자는 GitHub 계정을 통해 로그인한다. #2

### 구현/수정 내용
- snsId를 sns_id로 수정
- js에서는 camel-casing이 권장되지만, DB 모델과의 차이 때문에 헷갈리는 문제가 있어 sns_id로 통일
- logout 라우트를 추가
- isAuthenticated / isNotAuthenticated 미들웨어를 추가
    * ex) 로그인을 시도할 때는 isNotAuthenticated 라는 미들웨어를 거친다 => 로그인 안된 상태에서만 로그인 진행
    * ex) 로그아웃 시도할 때는 isAuthenticated 라는 미들웨어를 거친다 => 로그인 된 상태에서만 로그아웃 진행
- jwt-strategy 등록하는 코드에서 callback 이 호출되지 않는 오류 수정
- sns_id에는 profile.id가 아닌 profile.username 이 등록되도록 수정
    * github, kakao, google 로그인 등 여러 passport-strategy가 사용될 경우 profile.username은 unique 함을 보장할 수는 없지만 현재 프로젝트에서는 GitHub 소셜 로그인만을 사용할 예정이므로 크게 문제가 되지 않는다고 팀원들과 상의 및 합의하여 결정

### 테스트 결과
- **http://localhost:3000/auth/github/login 에 접근시**
![image](https://user-images.githubusercontent.com/38288479/97781731-b2180c00-1bd0-11eb-96d1-88e14ab278a5.png)
- **성공적으로 로그인 후에 client에는 json 반환**
![image](https://user-images.githubusercontent.com/38288479/97781736-be9c6480-1bd0-11eb-9f50-3710fce43db7.png)
- **jwt.io에서 decode 하여 확인하면**
![image](https://user-images.githubusercontent.com/38288479/97781781-f3102080-1bd0-11eb-9b06-ed08be503f39.png)

- **Postman을 이용한 로그아웃 테스트**
    * Authorization -> Bearer 토큰을 넣어준다
![image](https://user-images.githubusercontent.com/38288479/97781799-1aff8400-1bd1-11eb-87da-c75c3e7c1486.png)
![image](https://user-images.githubusercontent.com/38288479/97781807-205cce80-1bd1-11eb-84ae-a0a22c1a4b22.png)
- **토큰 없이 logout 요청 시 => unauthorized**
![image](https://user-images.githubusercontent.com/38288479/97781813-2ce12700-1bd1-11eb-89c9-a97df5a8ace5.png)
