### PR TITLE
이슈 목록에서 이슈 안에 포함되는 라벨 컴포넌트 추가

### DIFF
--- a/client/src/components/issue/IssueContent.jsx
+++ b/client/src/components/issue/IssueContent.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
+import IssueLabel from './IssueLabel';
 
 const IssueContentWrapper = styled.div`
   .issue-title {
@@ -16,8 +17,10 @@ const IssueContent = ({ issue }) => {
     <IssueContentWrapper>
       <div>
         <div className="issue-title issue-content">
-          <a></a>
-          {issue.title}
+          <a>{issue.title}</a>
+          {issue.labels.map((label) => (
+            <IssueLabel key={label.id} label={label} />
+          ))}
         </div>
         <div className="issue-content">
           <span>#{issue.id} opened yesterday by songjinhyun</span>

--- a/client/src/components/issue/IssueLabel.jsx
+++ b/client/src/components/issue/IssueLabel.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from 'styled-components';
+import IssueContext from '../../context/issues-context';
+
+const IssueLabelWrapper = styled.button`
+  background-color: ${(props) => props.color};
+  cursor: pointer;
+  border-radius: 10%;
+  font-weight: bold;
+`;
+const IssueLabel = ({ label }) => {
+  const { id, title, color } = label;
+  return (
+    <>
+      <IssueLabelWrapper key={'label' + id} color={color}>
+        <div>{label.title}</div>
+      </IssueLabelWrapper>
+    </>
+  );
+};
+
+export default IssueLabel;


### PR DESCRIPTION
## 해당 이슈
- 이슈 목록 ui 구현 #26 

## 구현/수정 내용
- IssueLabel 컴포넌트 생성
- IssueLabel 컴포넌트의 스타일 구현
- IssueContent에 IssueLabel 컴포넌트 삽입