### PR TITLE
Filterbar UI 구현, 기존 UI 약간 수정

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/client/src/components/issue/IssueContent.jsx
+++ b/client/src/components/issue/IssueContent.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
-import IssueLabel from './IssueLabel';
+import Label from '../label/Label';
 
 const IssueContentWrapper = styled.div`
   .issue-title {
@@ -19,7 +19,7 @@ const IssueContent = ({ issue }) => {
         <div className="issue-title issue-content">
           <a>{issue.title}</a>
           {issue.labels.map((label) => (
-            <IssueLabel key={label.id} label={label} />
+            <Label key={label.id} label={label} />
           ))}
         </div>
         <div className="issue-content">

--- a/client/src/components/issue/IssueItem.jsx
+++ b/client/src/components/issue/IssueItem.jsx
@@ -7,7 +7,7 @@ import { CHECK_ISSUE, UNCHECK_ISSUE } from '../../pages/issue-list/reducer';
 
 const IssueItemWrapper = styled.div`
   width: 80%;
-  height: 50px;
+  height: 75px;
   font-size: 14px;
   display: flex;
   margin: 0 auto;
@@ -17,6 +17,7 @@ const IssueItemWrapper = styled.div`
     background-color: #e9e9e9;
   }
   border: 1px solid #eaecef;
+  box-sizing: border-box;
 `;
 const IssueItem = ({ issue }) => {
   const { dispatch } = useContext(IssueContext);

--- a/client/src/components/issue/IssueItem.jsx
+++ b/client/src/components/issue/IssueItem.jsx
@@ -11,7 +11,6 @@ const IssueItemWrapper = styled.div`
   font-size: 14px;
   display: flex;
   margin: 0 auto;
-  margin-top: -1px;
   padding: 20px;
   &:hover {
     background-color: #e9e9e9;

--- a/client/src/components/issue/IssueLabel.jsx
+++ b/client/src/components/issue/IssueLabel.jsx
@@ -4,9 +4,12 @@ import IssueContext from '../../context/issues-context';
 
 const IssueLabelWrapper = styled.button`
   background-color: ${(props) => props.color};
+  border: none;
   cursor: pointer;
   border-radius: 10%;
   font-weight: bold;
+  margin-left: 5px;
+  outline: 0;
 `;
 const IssueLabel = ({ label }) => {
   const { id, title, color } = label;

--- a/client/src/components/issue/MenuContainer.jsx
+++ b/client/src/components/issue/MenuContainer.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styled from 'styled-components';
+import FilterBar from './filter/FilterBar';
+
+const Div = styled.div`
+  display: flex;
+  margin: 0 auto;
+  width: 80%;
+  margin-top: 70px;
+  margin-bottom: 40px;
+`;
+
+const MenuContainer = () => {
+  return (
+    <>
+      <Div>
+        <FilterBar />
+      </Div>
+    </>
+  );
+};
+
+export default MenuContainer;

--- a/client/src/components/issue/filter/FilterBar.jsx
+++ b/client/src/components/issue/filter/FilterBar.jsx
@@ -3,15 +3,17 @@ import styled from 'styled-components';
 
 const FilterBarWrapper = styled.div`
   display: flex;
+  width: 60%;
 `;
 
 const FilterButton = styled.button`
   font-size: 15px;
+  width: 20%;
   width: 100px;
   height: 35px;
   margin-right: 0;
   box-sizing: border-box;
-  border: 2px solid #eaecef;
+  border: 1px solid #eaecef;
   border-radius: 4px;
   background-color: #fafbfc;
   outline: 0;
@@ -34,9 +36,11 @@ const FilterText = styled.input.attrs({
   height: 35px;
   width: 300px;
   box-sizing: border-box;
-  border: 2px solid #eaecef;
+  border: 1px solid #eaecef;
   outline: 0;
   border-radius: 0 4px 4px 0;
+  background-color: #fafbfc;
+  width: 80%;
 `;
 
 const FilterBar = () => {

--- a/client/src/components/issue/filter/FilterBar.jsx
+++ b/client/src/components/issue/filter/FilterBar.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const FilterBarWrapper = styled.div`
+  display: flex;
+`;
+
+const FilterButton = styled.button`
+  font-size: 15px;
+  width: 100px;
+  height: 35px;
+  margin-right: 0;
+  box-sizing: border-box;
+  border: 2px solid #eaecef;
+  border-radius: 4px;
+  background-color: #fafbfc;
+  outline: 0;
+  &:hover {
+    background-color: #f3f4f6;
+  }
+`;
+
+const DropDownIcon = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+`;
+
+const FilterText = styled.input.attrs({
+  type: 'text',
+})`
+  margin-left: -6px;
+  height: 35px;
+  width: 300px;
+  box-sizing: border-box;
+  border: 2px solid #eaecef;
+  outline: 0;
+  border-radius: 0 4px 4px 0;
+`;
+
+const FilterBar = () => {
+  return (
+    <>
+      <FilterBarWrapper>
+        <FilterButton>
+          Filters
+          <DropDownIcon className="material-icons">
+            arrow_drop_down
+          </DropDownIcon>
+        </FilterButton>
+        <FilterText />
+      </FilterBarWrapper>
+    </>
+  );
+};
+
+export default FilterBar;

--- a/client/src/components/label/Label.jsx
+++ b/client/src/components/label/Label.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import IssueContext from '../../context/issues-context';
 
-const IssueLabelWrapper = styled.button`
+const LabelWrapper = styled.button`
   background-color: ${(props) => props.color};
   border: none;
   cursor: pointer;
@@ -11,15 +10,16 @@ const IssueLabelWrapper = styled.button`
   margin-left: 5px;
   outline: 0;
 `;
-const IssueLabel = ({ label }) => {
+
+const Label = ({ label }) => {
   const { id, title, color } = label;
   return (
     <>
-      <IssueLabelWrapper key={'label' + id} color={color}>
+      <LabelWrapper key={'label' + id} color={color}>
         <div>{label.title}</div>
-      </IssueLabelWrapper>
+      </LabelWrapper>
     </>
   );
 };
 
-export default IssueLabel;
+export default Label;

--- a/client/src/pages/issue-list/IssueListPage.jsx
+++ b/client/src/pages/issue-list/IssueListPage.jsx
@@ -2,6 +2,7 @@ import React, { useReducer } from 'react';
 import IssuesContext from '../../context/issues-context';
 import IssueContainer from '../../components/issue/IssueContainer';
 import reducer from './reducer';
+import MenuContainer from '../../components/issue/MenuContainer';
 
 const dummyIssues = [
   {
@@ -41,6 +42,7 @@ const IssueListPage = () => {
 
   return (
     <IssuesContext.Provider value={value}>
+      <MenuContainer />
       <IssueContainer />
     </IssuesContext.Provider>
   );


### PR DESCRIPTION
## 관련 이슈
[Epic] 이슈목록을 filters로 분류해서 볼 수 있다. #63 
[Task] 이슈목록 filters UI 구현 #70

## 구현/수정 사항
- filters UI를 구현하였습니다.
- 기존 UI에서 깨지는 부분을 수정하였습니다.
- IssueLabel 컴포넌트가 issue 쪽에 종속되지 않고 어디서든 쓰일 수 있기때문에 Label로 이름을 변경하였습니다.
- Label을 issue 폴더가아니라 label 폴더로 위치를 이동시켰습니다.

## 수정한 UI
![image](https://user-images.githubusercontent.com/26829633/98054851-722a8080-1e7f-11eb-9d73-62a634b13345.png)

