### PR TITLE
issue 조회 api  assignees 목록도 가져오도록 수정

### DIFF
--- a/server/src/controllers/issue.js
+++ b/server/src/controllers/issue.js
@@ -6,12 +6,18 @@ const getAllIssues = async (req, res, next) => {
     include: [
       {
         model: User,
-        attributes: ['user_id', 'sns_id'],
+        attributes: ['id', 'user_id', 'sns_id'],
       },
       {
         model: Label,
         as: 'labels',
         attributes: ['id', 'title', 'description', 'color'],
+        through: { attributes: [] },
+      },
+      {
+        model: User,
+        as: 'assignees',
+        attributes: ['id', 'user_id', 'sns_id'],
         through: { attributes: [] },
       },
       {

--- a/server/src/models/issue.js
+++ b/server/src/models/issue.js
@@ -38,7 +38,7 @@ module.exports = (sequelize, DataTypes) => {
       onUpdate: 'cascade',
     });
     issue.belongsToMany(models.User, {
-      as: 'users',
+      as: 'assignees',
       through: 'issue_user',
       foreignKey: 'issue_id',
       timestamps: false,

--- a/server/src/tests/issues.test.js
+++ b/server/src/tests/issues.test.js
@@ -7,6 +7,7 @@ describe('GET /issues 이슈목록 조회 API 테스트', () => {
   it('인증된 사용자의 정상 요청일 경우 200 status code를 응답한다', async (done) => {
     const res = await request(app).get('/issues').set('Authorization', `Bearer ${token}`);
     expect(res.status).toEqual(200);
+    console.log(res.toJSON());
     done();
   });
 });


### PR DESCRIPTION
## 관련 이슈
이슈 목록 조회 api #27 

## 구현/수정 사항
- 이슈와 연관된 assignees 목록도 가져오도록 이슈목록 조회 api를 수정하였습니다.

## 결과
```
[
    {
        "id": 1,
        "title": "버그 픽스!",
        "content": "내용 테스트",
        "state": "open",
        "created_at": "2020-11-03T17:26:00.000Z",
        "user": {
            "user_id": null,
            "sns_id": "mu1616"
        },
        "labels": [
            {
                "id": 1,
                "title": "bug",
                "description": "bug",
                "color": "#f9d0c4"
            },
            {
                "id": 2,
                "title": "Must",
                "description": "Priority: Must",
                "color": "#028e87"
            }
        ],
        "assignees": [
            {
                "user_id": null,
                "sns_id": "jch422"
            },
            {
                "user_id": null,
                "sns_id": "mu1616"
            }
        ],
        "milestone": {
            "id": 1,
            "title": "sprint1",
            "description": "sprint1",
            "due_date": "2020-11-03T08:47:08.000Z",
            "state": "open"
        }
    },
    {
        "id": 2,
        "title": "리액트 환경설정",
        "content": "환경설정중",
        "state": "open",
        "created_at": "2020-11-03T17:30:49.000Z",
        "user": {
            "user_id": null,
            "sns_id": "jch422"
        },
        "labels": [
            {
                "id": 2,
                "title": "Must",
                "description": "Priority: Must",
                "color": "#028e87"
            }
        ],
        "assignees": [],
        "milestone": null
    }
]
```