### PR TITLE
이슈 목록 페이지의 검색창 UI 구현 및 검색창 text를 context로 등록

### DIFF
--- a/client/src/components/issue/MenuContainer.jsx
+++ b/client/src/components/issue/MenuContainer.jsx
@@ -1,9 +1,10 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useContext } from 'react';
 import styled from 'styled-components';
 import FilterBar from './filter/FilterBar';
 import NavigationContainer from './NavigationContainer';
 import CreateButton from './CreateButton';
 import FilterMenuDropDown from './filter/FilterMenuDropDown';
+import { IssuesContext } from '../../pages/issue-list/IssueListPage';
 
 const Div = styled.div`
   display: flex;
@@ -18,6 +19,9 @@ export const FilterMenuContext = React.createContext();
 
 const MenuContainer = () => {
   const [showFilterMenu, setFilterMenu] = useState(false);
+  const { state } = useContext(IssuesContext);
+  const { searchText } = state;
+
   const onClickFilterButton = () => setFilterMenu(!showFilterMenu);
 
   return (
@@ -26,6 +30,7 @@ const MenuContainer = () => {
         <FilterBar
           onClickFilterButton={onClickFilterButton}
           setFilterMenu={setFilterMenu}
+          searchText={searchText}
         />
         <NavigationContainer />
         <CreateButton />

--- a/client/src/components/issue/filter/FilterBar.jsx
+++ b/client/src/components/issue/filter/FilterBar.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import styled from 'styled-components';
 import DropDownIcon from '../../common/DropDownIcon';
+import FilterForm from './FilterForm';
 
 const FilterBarWrapper = styled.div`
   display: flex;
@@ -23,19 +24,6 @@ const FilterButton = styled.button`
   }
 `;
 
-const FilterText = styled.input.attrs({
-  type: 'text',
-})`
-  margin-left: -6px;
-  height: 35px;
-  box-sizing: border-box;
-  border: 1px solid #eaecef;
-  outline: 0;
-  border-radius: 0 4px 4px 0;
-  background-color: #fafbfc;
-  width: 85%;
-`;
-
 const FilterBar = ({ onClickFilterButton, setFilterMenu }) => {
   const filterButtonRef = useRef();
 
@@ -54,7 +42,7 @@ const FilterBar = ({ onClickFilterButton, setFilterMenu }) => {
           Filters
           <DropDownIcon />
         </FilterButton>
-        <FilterText />
+        <FilterForm />
       </FilterBarWrapper>
     </>
   );

--- a/client/src/components/issue/filter/FilterBar.jsx
+++ b/client/src/components/issue/filter/FilterBar.jsx
@@ -24,7 +24,7 @@ const FilterButton = styled.button`
   }
 `;
 
-const FilterBar = ({ onClickFilterButton, setFilterMenu }) => {
+const FilterBar = ({ onClickFilterButton, setFilterMenu, searchText }) => {
   const filterButtonRef = useRef();
 
   useEffect(() => {
@@ -42,7 +42,7 @@ const FilterBar = ({ onClickFilterButton, setFilterMenu }) => {
           Filters
           <DropDownIcon />
         </FilterButton>
-        <FilterForm />
+        <FilterForm searchText={searchText} />
       </FilterBarWrapper>
     </>
   );

--- a/client/src/components/issue/filter/FilterForm.jsx
+++ b/client/src/components/issue/filter/FilterForm.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import svg from '../../../utils/svg';
 
 const FormWrapper = styled.form`
   margin-left: -6px;
@@ -10,7 +11,7 @@ const FormWrapper = styled.form`
   border-radius: 0 4px 4px 0;
   background-color: #fafbfc;
   position: relative;
-  .search-svg {
+  & svg {
     margin: 0 8px 0 8px;
     position: absolute;
     top: 7px;
@@ -42,13 +43,7 @@ const FilterForm = ({ searchText }) => {
     <>
       <FormWrapper>
         <FilterInput value={searchText} />
-        <svg className="search-svg" width="20" height="20">
-          <path
-            fillRule="evenodd"
-            d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
-            fill="#959da5"
-          ></path>
-        </svg>
+        {svg['magnifyingGlass']}
       </FormWrapper>
     </>
   );

--- a/client/src/components/issue/filter/FilterForm.jsx
+++ b/client/src/components/issue/filter/FilterForm.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const FormWrapper = styled.form`
+  margin-left: -6px;
+  height: 35px;
+  width: 85%;
+  box-sizing: border-box;
+  border: 1px solid #eaecef;
+  border-radius: 0 4px 4px 0;
+  background-color: #fafbfc;
+  position: relative;
+  .search-svg {
+    margin: 0 8px 0 8px;
+    position: absolute;
+    top: 7px;
+    left: 0px;
+  }
+`;
+
+const FilterInput = styled.input.attrs({
+  type: 'text',
+  placeholder: 'Search all issues',
+})`
+  font-size: 17px;
+  padding-left: 6%;
+  height: 29px;
+  width: 93.5%;
+  border: none;
+  color: #6a737d;
+  &:focus {
+    outline: none;
+    border: 0.5px solid #0366d6;
+    border-radius: 0 4px 4px 0;
+    box-shadow: 0px 0px 2.5px 2.5px #b3d1f3;
+  }
+`;
+
+const FilterForm = () => {
+  return (
+    <>
+      <FormWrapper>
+        <FilterInput />
+        <svg className="search-svg" width="20" height="20">
+          <path
+            fillRule="evenodd"
+            d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
+            fill="#959da5"
+          ></path>
+        </svg>
+      </FormWrapper>
+    </>
+  );
+};
+
+export default FilterForm;

--- a/client/src/components/issue/filter/FilterForm.jsx
+++ b/client/src/components/issue/filter/FilterForm.jsx
@@ -18,10 +18,11 @@ const FormWrapper = styled.form`
   }
 `;
 
-const FilterInput = styled.input.attrs({
+const FilterInput = styled.input.attrs((props) => ({
   type: 'text',
   placeholder: 'Search all issues',
-})`
+  value: props.value,
+}))`
   font-size: 17px;
   padding-left: 6%;
   height: 29px;
@@ -36,11 +37,11 @@ const FilterInput = styled.input.attrs({
   }
 `;
 
-const FilterForm = () => {
+const FilterForm = ({ searchText }) => {
   return (
     <>
       <FormWrapper>
-        <FilterInput />
+        <FilterInput value={searchText} />
         <svg className="search-svg" width="20" height="20">
           <path
             fillRule="evenodd"

--- a/client/src/pages/issue-list/IssueListPage.jsx
+++ b/client/src/pages/issue-list/IssueListPage.jsx
@@ -14,6 +14,7 @@ export const IssuesContext = React.createContext();
 
 const initialState = {
   wholeCheck: false,
+  searchText: 'is:open is:issue ',
   renderedIssues: [],
   issues: [],
   labels: [],

--- a/client/src/utils/svg.js
+++ b/client/src/utils/svg.js
@@ -49,6 +49,15 @@ const svg = {
       ></path>
     </svg>
   ),
+  magnifyingGlass: (
+    <svg width="20" height="20">
+      <path
+        fillRule="evenodd"
+        d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"
+        fill="#959da5"
+      ></path>
+    </svg>
+  ),
 };
 
 export default svg;


### PR DESCRIPTION
## 관련 이슈
- [Epic] 이슈목록을 filters로 분류해서 볼 수 있다. #63
- [Task] 이슈 목록 filters ui 구현 #70

## 구현 내용
- 검색창 컴포넌트 별도로 분리
- 검색창의 text를 context로 등록
- 등록한 text props로 넘기며 이후 작업을 위한 사전 작업 진행
- 검색창에 돋보기 모양 추가 및 세부 디자인 구현

![image](https://user-images.githubusercontent.com/23556120/98470523-74972c80-2229-11eb-9443-9809b14b0450.png)
