### PR TITLE
Load Spinner 추가 및 이슈생성페이지 context 추가 (수정 진행중)

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,7 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css"
+    />
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/client/src/components/common/Spinner.js
+++ b/client/src/components/common/Spinner.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Spinner = () => {
+  return (
+    <div className="ui active dimmer">
+      <div className="ui big text loader">Loading...</div>
+    </div>
+  );
+};
+
+export default Spinner;

--- a/client/src/components/issue/new/sidebar/Dropdown.jsx
+++ b/client/src/components/issue/new/sidebar/Dropdown.jsx
@@ -4,12 +4,6 @@ import AssigneeOption from './UserOption';
 import LabelOption from './LabelOption';
 import MilestoneOption from './MilestoneOption';
 
-const components = {
-  assignees: AssigneeOption,
-  labels: LabelOption,
-  milestones: MilestoneOption,
-};
-
 const DropdownWrapper = styled.div`
   position: absolute;
   top: 40px;
@@ -34,15 +28,17 @@ const DropdownWrapper = styled.div`
   }
 `;
 
-const Dropdown = ({ show, item, data, handleClose }) => {
+const components = {
+  users: AssigneeOption,
+  labels: LabelOption,
+  milestones: MilestoneOption,
+};
+
+const Dropdown = ({ show, item, data }) => {
   const dropdownDisplay = show ? 'display-block' : 'display-none';
   const Component = components[item];
   const options = data.map((option, index) => (
-    <div
-      className="dropdown-option"
-      key={'dropdown' + index}
-      onClick={handleClose}
-    >
+    <div className="dropdown-option" key={'dropdown' + index}>
       <Component data={option} />
     </div>
   ));

--- a/client/src/components/issue/new/sidebar/Sidebar.jsx
+++ b/client/src/components/issue/new/sidebar/Sidebar.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 import SidebarItem from './SidebarItem';
-
+//
+import AssigneeOption from './UserOption';
+import LabelOption from './LabelOption';
+import MilestoneOption from './MilestoneOption';
+// component, selected 전부 다 하위로 내려주기
+//
 const SidebarWrapper = styled.div`
   flex-basis: 23%;
   width: 16%;
@@ -9,7 +14,7 @@ const SidebarWrapper = styled.div`
 
 const Sidebar = () => {
   const defaultItems = [
-    { title: 'Assignees', stateMsg: 'No one', data: 'assignees' },
+    { title: 'Assignees', stateMsg: 'No one', data: 'users' },
     { title: 'Labels', stateMsg: 'None yet', data: 'labels' },
     { title: 'Milestone', stateMsg: 'No milestone', data: 'milestones' },
   ];

--- a/client/src/components/issue/new/sidebar/SidebarItem.jsx
+++ b/client/src/components/issue/new/sidebar/SidebarItem.jsx
@@ -1,9 +1,8 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useContext } from 'react';
 import styled from 'styled-components';
 import Heading from './Heading';
 import Dropdown from './Dropdown';
-// import { getAllLabels } from '../../../../lib/axios/label';
-// import { getAllMilestones } from '../../../../lib/axios/milestone.js';
+import { IssueOptionContext } from '../../../../pages/issue-new/IssueNewPage';
 
 const SidebarItemWrapper = styled.div`
   position: relative;
@@ -18,68 +17,10 @@ const StateMsg = styled.div`
   color: #586069;
   font-size: 12px;
 `;
-const labels = [
-  {
-    id: 1,
-    title: 'Frontend',
-    description: 'Something in Frontend',
-    color: '#AAED8B',
-  },
-  {
-    id: 2,
-    title: 'Backend',
-    description: 'Something in Backend : 백엔드',
-    color: '#0052CC',
-  },
-  { id: 3, title: 'Environment', description: '환경설정', color: '#F9D0C4' },
-  {
-    id: 4,
-    title: 'Bugfix: build',
-    description: '빌드 관련 버그 수정',
-    color: '#D73A4A',
-  },
-  { id: 5, title: '🥇Must', description: '우선순위: 상', color: '#E57559' },
-  { id: 6, title: '🥈Should', description: '우선순위: 중', color: '#E57559' },
-  { id: 7, title: '🥉Could', description: '우선순위: 하', color: '#E57559' },
-];
-const milestones = [
-  {
-    id: 1,
-    title: 'sprint-1',
-    description: 'sprint 1주차',
-    due_date: '2020-11-03 24:00:00',
-    state: 'closed',
-  },
-  {
-    id: 2,
-    title: 'sprint-2',
-    description: 'sprint 2주차',
-    due_date: '2020-11-10 24:00:00',
-    state: 'open',
-  },
-  {
-    id: 3,
-    title: 'sprint-3',
-    description: 'sprint 3주차',
-    due_date: '2020-11-17 24:00:00',
-    state: 'open',
-  },
-];
-const users = [
-  { id: 1, sns_id: 'qkrrlgh519' },
-  { id: 2, sns_id: 'mu1616' },
-  { id: 3, sns_id: 'jch422' },
-  { id: 4, sns_id: 'thdwlsgus0' },
-];
-const data = {
-  assignees: users,
-  labels,
-  milestones,
-};
 
 const SidebarItem = ({ title, stateMsg, item }) => {
+  const { state } = useContext(IssueOptionContext);
   const [show, setShow] = useState(false);
-
   const ref = useRef();
 
   useEffect(() => {
@@ -92,20 +33,12 @@ const SidebarItem = ({ title, stateMsg, item }) => {
   const handleOnClick = () => {
     setShow(!show);
   };
-  const hideDropdown = () => {
-    setShow(false);
-  };
 
   return (
     <SidebarItemWrapper ref={ref}>
       <Heading title={title} onClick={handleOnClick} />
       <StateMsg>{stateMsg}</StateMsg>
-      <Dropdown
-        show={show}
-        item={item}
-        data={data[item]}
-        handleClose={hideDropdown}
-      />
+      <Dropdown show={show} item={item} data={state[item]} />
     </SidebarItemWrapper>
   );
 };

--- a/client/src/pages/issue-list/IssueListPage.jsx
+++ b/client/src/pages/issue-list/IssueListPage.jsx
@@ -9,6 +9,7 @@ import { getAllMilestones } from '../../lib/axios/milestone';
 import { getCurrentUser, getAllUsers } from '../../lib/axios/user';
 import { INIT_DATA } from '../../pages/issue-list/reducer';
 import ToolBarContainer from '../../components/issue/ToolBarContainer';
+import Spinner from '../../components/common/Spinner';
 
 export const IssuesContext = React.createContext();
 
@@ -42,7 +43,7 @@ const IssueListPage = () => {
       <Header />
       <MenuContainer />
       <ToolBarContainer />
-      <IssueContainer />
+      {state.renderedIssues ? <IssueContainer /> : <Spinner />}
     </IssuesContext.Provider>
   );
 };

--- a/client/src/pages/issue-new/IssueNewPage.jsx
+++ b/client/src/pages/issue-new/IssueNewPage.jsx
@@ -1,10 +1,14 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useReducer } from 'react';
 import Header from '../../components/Header';
 import styled from 'styled-components';
 import { AppContext } from '../../App';
 import IssueNewContent from '../../components/issue/new/IssueNewContent';
+import reducer from './reducer.js';
 import Sidebar from '../../components/issue/new/sidebar/Sidebar';
 import ProfileImage from '../../components/common/ProfileImage';
+import { getAllLabels } from '../../lib/axios/label';
+import { getAllMilestones } from '../../lib/axios/milestone';
+import { getAllUsers } from '../../lib/axios/user';
 
 const IssueNewPageWrapper = styled.div`
   display: flex;
@@ -21,10 +25,35 @@ const IssueNewPageWrapper = styled.div`
   }
 `;
 
+export const IssueOptionContext = React.createContext();
+
+const initialState = {
+  users: [],
+  labels: [],
+  milestones: [],
+  addedAssignees: [],
+  addedLabels: [],
+  addedMilestone: null,
+};
+
 const IssueListNewPage = () => {
   const { currentUser } = useContext(AppContext);
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  useEffect(async () => {
+    const [labels, milestones, users] = await Promise.all([
+      getAllLabels(),
+      getAllMilestones(),
+      getAllUsers(),
+    ]);
+    dispatch({
+      type: 'INIT_DATA',
+      data: { labels, milestones, users },
+    });
+  }, []);
+
   return (
-    <>
+    <IssueOptionContext.Provider value={{ state, dispatch }}>
       <Header />
       <IssueNewPageWrapper>
         <div class="content-wrapper">
@@ -33,7 +62,7 @@ const IssueListNewPage = () => {
         </div>
         <Sidebar />
       </IssueNewPageWrapper>
-    </>
+    </IssueOptionContext.Provider>
   );
 };
 

--- a/client/src/pages/issue-new/reducer.js
+++ b/client/src/pages/issue-new/reducer.js
@@ -1,0 +1,26 @@
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'INIT_DATA':
+      return {
+        ...state,
+        ...action.data,
+      };
+    case 'ADD_ASSIGNEE':
+      return {
+        ...state,
+        addedAssignees: [state.addedAssignees, action.assignee],
+      };
+    case 'ADD_LABEL':
+      return {
+        ...state,
+        addedLabels: [state.addedLabels, action.label],
+      };
+    case 'SET_MILESTONE':
+      return {
+        ...state,
+        addedMilestone: action.milestone,
+      };
+  }
+};
+
+export default reducer;

--- a/server/src/controllers/issue.js
+++ b/server/src/controllers/issue.js
@@ -29,12 +29,21 @@ const getAllIssues = async (req, res, next) => {
   res.status(200).json(issues);
 };
 const createIssue = async (req, res, next) => {
-  const { title, content, user_id } = { ...req.body };
+  const { title, content, user_id, milestone_id, labels } = { ...req.body };
   const issue = await Issue.create({
     title,
     content,
     user_id,
+    milestone_id,
   });
+
+  if (labels) {
+    const promises = labels.map((label) => {
+      return issue.addLabels(label);
+    });
+    Promise.all(promises);
+  }
+
   res.status(200).json(issue);
 };
 module.exports = { getAllIssues, createIssue };


### PR DESCRIPTION
## 관련 이슈
- 이슈 생성 ui 구현 #57
- 이슈 생성 api #58
- 이슈 생성 이벤트 구현 #60
## 구현 / 수정 내용
- 초기 렌더값이 없을 경우 load spinner 가 화면에 보이도록 semantic-ui 추가
    * 확인을 위해서 IssueListPage.jsx 에서 46 째줄을
```{state.renderedIssues ? <Spinner /> : <Spinner />} ``` 로 수정하면 확인가능(현재는 데이터 로딩이 빨라서 로드 스피너가 보이지않음)
- 이슈 생성페이지에서 사용할 context 및 reducer 추가