### PR TITLE
마일스톤 편집 페이지 구현

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import MilestonePage from './pages/milestone-list/MilestonePage';
 import { getToken } from './utils/token';
 import { getCurrentUser } from './lib/axios/user';
 import MilestoneNewPage from './pages/MilestoneNewPage';
+import MilestoneEditPage from './pages/MilestoneEditPage';
 
 const GlobalStyle = createGlobalStyle`
   body{
@@ -40,8 +41,13 @@ const App = () => {
           <Route exact path="/" component={LoginPage} />
           <Route exact path="/issues" component={IssueListPage} />
           <Route exact path="/issues/new" component={IssueNewPage} />
-          <Route exact path="/milestones" component={MilestonePage}/>
+          <Route exact path="/milestones" component={MilestonePage} />
           <Route exact path="/milestones/new" component={MilestoneNewPage} />
+          <Route
+            exact
+            path="/milestones/:id/edit"
+            component={MilestoneEditPage}
+          />
           <Route component={NotFoundPage} />
         </Switch>
       </Router>

--- a/client/src/components/common/GreyButton.jsx
+++ b/client/src/components/common/GreyButton.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Button = styled.button`
+  background-color: #fafbfc;
+  border: 1px solid #eaecef;
+  border-radius: 4px;
+  height: 35px;
+  font-size: 14px;
+  outline: 0;
+  font-weight: bold;
+  padding: 0px 15px 0px 15px;
+  cursor: pointer;
+`;
+
+const GreyButton = ({ text, func }) => {
+  return (
+    <>
+      <Button onClick={func}>{text}</Button>
+    </>
+  );
+};
+
+export default GreyButton;

--- a/client/src/components/common/LabelComponent.jsx
+++ b/client/src/components/common/LabelComponent.jsx
@@ -1,29 +1,33 @@
 import React from 'react';
 import styled from 'styled-components';
 const LabelComponentWrapper = styled.div`
-   width:${(props)=>(props.title === "Labels"? "100px":"130px")};
-   height:30px;
-   background-color:#fff;
-   border:1px solid #E1E4E8;
-   cursor:pointer;
-   font-weight:bold;
-   box-sizing:border-box;
-   padding:5px 15px;
-   border-top-left-radius:${(props)=>(props.title === "Labels"? "5px":"0px")};
-   border-bottom-left-radius:${(props)=>(props.title === "Labels"? "5px":"0px")};
-   border-top-right-radius:${(props)=>(props.title === "Milestones"? "5px":"0px")};
-   border-bottom-right-radius:${(props)=>(props.title === "Milestones"? "5px":"0px")};
+  width: ${(props) => (props.title === 'Labels' ? '100px' : '140px')};
+  height: 30px;
+  background-color: #fff;
+  border: 1px solid #e1e4e8;
+  cursor: pointer;
+  font-weight: bold;
+  box-sizing: border-box;
+  padding: 5px 15px;
+  border-top-left-radius: ${(props) =>
+    props.title === 'Labels' ? '5px' : '0px'};
+  border-bottom-left-radius: ${(props) =>
+    props.title === 'Labels' ? '5px' : '0px'};
+  border-top-right-radius: ${(props) =>
+    props.title === 'Milestones' ? '5px' : '0px'};
+  border-bottom-right-radius: ${(props) =>
+    props.title === 'Milestones' ? '5px' : '0px'};
 `;
 
-const LabelComponent = ({svg, title}) =>{
-    return (
-      <>
-        <LabelComponentWrapper title={title}>
-            {svg}
-            {title}
-        </LabelComponentWrapper>
-      </>
-    );
-}
+const LabelComponent = ({ svg, title, func }) => {
+  return (
+    <>
+      <LabelComponentWrapper title={title} onClick={func}>
+        {svg}
+        {title}
+      </LabelComponentWrapper>
+    </>
+  );
+};
 
 export default LabelComponent;

--- a/client/src/components/milestone/InputDate.jsx
+++ b/client/src/components/milestone/InputDate.jsx
@@ -24,11 +24,11 @@ const Input = styled.input.attrs((props) => ({
   }
 `;
 
-const InputDate = memo(({ setDate }) => {
+const InputDate = memo(({ setDate, value }) => {
   const onChangeInput = (e) => {
     setDate(e.target.value);
   };
-  return <Input onChange={onChangeInput} />;
+  return <Input onChange={onChangeInput} value={value} />;
 });
 
 export default InputDate;

--- a/client/src/components/milestone/MilestoneCreateForm.jsx
+++ b/client/src/components/milestone/MilestoneCreateForm.jsx
@@ -24,7 +24,7 @@ const Line = styled.div`
   border-bottom: 1px solid #eaecef;
 `;
 
-const MilestoneForm = () => {
+const MilestoneCreateForm = () => {
   const [title, setTitle] = useState('');
   const [date, setDate] = useState(null);
   const [description, setDescription] = useState('');
@@ -64,4 +64,4 @@ const MilestoneForm = () => {
   );
 };
 
-export default MilestoneForm;
+export default MilestoneCreateForm;

--- a/client/src/components/milestone/MilestoneEditForm.jsx
+++ b/client/src/components/milestone/MilestoneEditForm.jsx
@@ -56,6 +56,8 @@ const MilestoneEditForm = ({ milestoneId }) => {
     history.push('/milestones');
   };
 
+  const onClickCancel = () => history.push('/milestones');
+
   return (
     <Form>
       <InputWrapper>
@@ -92,7 +94,7 @@ const MilestoneEditForm = ({ milestoneId }) => {
           />
         </div>
         <div className="btn">
-          <GreyButton text={'Cancel'} />
+          <GreyButton text={'Cancel'} func={onClickCancel} />
         </div>
       </ButtonWrapper>
     </Form>

--- a/client/src/components/milestone/MilestoneEditForm.jsx
+++ b/client/src/components/milestone/MilestoneEditForm.jsx
@@ -6,7 +6,7 @@ import InputTitle from './InputTitle';
 import DescriptionArea from './DescriptionArea';
 import GreenButton from '../common/GreenButton';
 import GreyButton from '../common/GreyButton';
-import { getMilestone } from '../../lib/axios/milestone';
+import { getMilestone, updateMilestone } from '../../lib/axios/milestone';
 import { useHistory } from 'react-router-dom';
 import { getFormattedDate } from '../../utils/time';
 
@@ -46,6 +46,16 @@ const MilestoneEditForm = ({ milestoneId }) => {
     setId(milestone.id);
   }, []);
 
+  const onClickSave = async () => {
+    await updateMilestone(milestoneId, {
+      title,
+      description,
+      due_date: date,
+      state,
+    });
+    history.push('/milestones');
+  };
+
   return (
     <Form>
       <InputWrapper>
@@ -74,7 +84,7 @@ const MilestoneEditForm = ({ milestoneId }) => {
       <Line />
       <ButtonWrapper>
         <div className="btn">
-          <GreenButton text={'Save changes'} />
+          <GreenButton text={'Save changes'} func={onClickSave} />
         </div>
         <div className="btn">
           <GreyButton

--- a/client/src/components/milestone/MilestoneEditForm.jsx
+++ b/client/src/components/milestone/MilestoneEditForm.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import InputWrapper from './InputWrapper';
+import InputDate from './InputDate';
+import InputTitle from './InputTitle';
+import DescriptionArea from './DescriptionArea';
+import GreenButton from '../common/GreenButton';
+import GreyButton from '../common/GreyButton';
+import { createMilestone } from '../../lib/axios/milestone';
+import { useHistory } from 'react-router-dom';
+
+const Form = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: row-reverse;
+  margin-top: 10px;
+  .btn {
+    margin-left: 5px;
+  }
+`;
+
+const Line = styled.div`
+  height: 10px;
+  border-bottom: 1px solid #eaecef;
+`;
+
+const MilestoneEditForm = () => {
+  const [title, setTitle] = useState('');
+  const [date, setDate] = useState(null);
+  const [description, setDescription] = useState('');
+  const history = useHistory();
+
+  return (
+    <Form>
+      <InputWrapper>
+        <div className="title">Title</div>
+        <InputTitle title={title} setTitle={setTitle} />
+      </InputWrapper>
+      <InputWrapper>
+        <div className="title">Due date (optional)</div>
+        <InputDate date={date} setDate={setDate} />
+      </InputWrapper>
+      <InputWrapper>
+        <div className="title">Description</div>
+        <DescriptionArea
+          description={description}
+          setDescription={setDescription}
+        />
+      </InputWrapper>
+      <Line />
+      <ButtonWrapper>
+        <div className="btn">
+          <GreenButton text={'Save changes'} />
+        </div>
+        <div className="btn">
+          <GreyButton text={'Close milestone'} />
+        </div>
+        <div className="btn">
+          <GreyButton text={'Cancel'} />
+        </div>
+      </ButtonWrapper>
+    </Form>
+  );
+};
+
+export default MilestoneEditForm;

--- a/client/src/components/milestone/MilestoneEditForm.jsx
+++ b/client/src/components/milestone/MilestoneEditForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import InputWrapper from './InputWrapper';
 import InputDate from './InputDate';
@@ -6,8 +6,9 @@ import InputTitle from './InputTitle';
 import DescriptionArea from './DescriptionArea';
 import GreenButton from '../common/GreenButton';
 import GreyButton from '../common/GreyButton';
-import { createMilestone } from '../../lib/axios/milestone';
+import { getMilestone } from '../../lib/axios/milestone';
 import { useHistory } from 'react-router-dom';
+import { getFormattedDate } from '../../utils/time';
 
 const Form = styled.div`
   display: flex;
@@ -28,11 +29,22 @@ const Line = styled.div`
   border-bottom: 1px solid #eaecef;
 `;
 
-const MilestoneEditForm = () => {
+const MilestoneEditForm = ({ milestoneId }) => {
+  const [id, setId] = useState(null);
   const [title, setTitle] = useState('');
   const [date, setDate] = useState(null);
   const [description, setDescription] = useState('');
+  const [state, setState] = useState('');
   const history = useHistory();
+
+  useEffect(async () => {
+    const milestone = await getMilestone(milestoneId);
+    setTitle(milestone.title);
+    setDate(milestone.due_date);
+    setDescription(milestone.description);
+    setState(milestone.state);
+    setId(milestone.id);
+  }, []);
 
   return (
     <Form>
@@ -42,7 +54,15 @@ const MilestoneEditForm = () => {
       </InputWrapper>
       <InputWrapper>
         <div className="title">Due date (optional)</div>
-        <InputDate date={date} setDate={setDate} />
+        <InputDate
+          date={date}
+          setDate={setDate}
+          value={
+            date
+              ? getFormattedDate({ date: new Date(date), format: '-' })
+              : '연도-월-일'
+          }
+        />
       </InputWrapper>
       <InputWrapper>
         <div className="title">Description</div>
@@ -57,7 +77,9 @@ const MilestoneEditForm = () => {
           <GreenButton text={'Save changes'} />
         </div>
         <div className="btn">
-          <GreyButton text={'Close milestone'} />
+          <GreyButton
+            text={state === 'open' ? 'Close milestone' : 'Reopen milestone'}
+          />
         </div>
         <div className="btn">
           <GreyButton text={'Cancel'} />

--- a/client/src/components/milestone/MilestoneEditForm.jsx
+++ b/client/src/components/milestone/MilestoneEditForm.jsx
@@ -6,9 +6,14 @@ import InputTitle from './InputTitle';
 import DescriptionArea from './DescriptionArea';
 import GreenButton from '../common/GreenButton';
 import GreyButton from '../common/GreyButton';
-import { getMilestone, updateMilestone } from '../../lib/axios/milestone';
+import {
+  getMilestone,
+  updateMilestone,
+  patchMilestone,
+} from '../../lib/axios/milestone';
 import { useHistory } from 'react-router-dom';
 import { getFormattedDate } from '../../utils/time';
+import milestone from '../../../../server/src/models/milestone';
 
 const Form = styled.div`
   display: flex;
@@ -58,6 +63,12 @@ const MilestoneEditForm = ({ milestoneId }) => {
 
   const onClickCancel = () => history.push('/milestones');
 
+  const onClickChangeState = async () => {
+    const changedState = state === 'open' ? 'close' : 'open';
+    await patchMilestone(milestoneId, { state: changedState });
+    history.push('/milestones');
+  };
+
   return (
     <Form>
       <InputWrapper>
@@ -91,6 +102,7 @@ const MilestoneEditForm = ({ milestoneId }) => {
         <div className="btn">
           <GreyButton
             text={state === 'open' ? 'Close milestone' : 'Reopen milestone'}
+            func={onClickChangeState}
           />
         </div>
         <div className="btn">

--- a/client/src/lib/axios/milestone.js
+++ b/client/src/lib/axios/milestone.js
@@ -1,9 +1,10 @@
-import { getData, postData } from './request';
+import { getData, postData, putData } from './request';
 
 const url = {
   GET_ALL_MILESTONES: 'milestones',
   CREATE_MILESTONE: 'milestones',
   GET_MILESTONE: 'milestones/',
+  UPDATE_MILESTONE: 'milestones/',
 };
 
 export const getAllMilestones = async () => {
@@ -18,5 +19,10 @@ export const createMilestone = async (body) => {
 
 export const getMilestone = async (id) => {
   const milestone = await getData(`${url.GET_MILESTONE}${id}`);
+  return milestone;
+};
+
+export const updateMilestone = async (id, body) => {
+  const milestone = await putData(`${url.GET_MILESTONE}${id}`, body);
   return milestone;
 };

--- a/client/src/lib/axios/milestone.js
+++ b/client/src/lib/axios/milestone.js
@@ -1,10 +1,11 @@
-import { getData, postData, putData } from './request';
+import { getData, postData, putData, patchData } from './request';
 
 const url = {
   GET_ALL_MILESTONES: 'milestones',
   CREATE_MILESTONE: 'milestones',
   GET_MILESTONE: 'milestones/',
   UPDATE_MILESTONE: 'milestones/',
+  PATCH_MILESTONE: 'milestones/',
 };
 
 export const getAllMilestones = async () => {
@@ -24,5 +25,10 @@ export const getMilestone = async (id) => {
 
 export const updateMilestone = async (id, body) => {
   const milestone = await putData(`${url.GET_MILESTONE}${id}`, body);
+  return milestone;
+};
+
+export const patchMilestone = async (id, body) => {
+  const milestone = await patchData(`${url.GET_MILESTONE}${id}`, body);
   return milestone;
 };

--- a/client/src/lib/axios/milestone.js
+++ b/client/src/lib/axios/milestone.js
@@ -3,6 +3,7 @@ import { getData, postData } from './request';
 const url = {
   GET_ALL_MILESTONES: 'milestones',
   CREATE_MILESTONE: 'milestones',
+  GET_MILESTONE: 'milestones/',
 };
 
 export const getAllMilestones = async () => {
@@ -12,5 +13,10 @@ export const getAllMilestones = async () => {
 
 export const createMilestone = async (body) => {
   const milestone = await postData(url.CREATE_MILESTONE, body);
+  return milestone;
+};
+
+export const getMilestone = async (id) => {
+  const milestone = await getData(`${url.GET_MILESTONE}${id}`);
   return milestone;
 };

--- a/client/src/pages/MilestoneEditPage.jsx
+++ b/client/src/pages/MilestoneEditPage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const MilestoneEditPage = ({ match }) => {
+  console.log(match.params.id);
+  return <></>;
+};
+
+export default MilestoneEditPage;

--- a/client/src/pages/MilestoneEditPage.jsx
+++ b/client/src/pages/MilestoneEditPage.jsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import styled from 'styled-components';
-import { getMilestone } from '../lib/axios/milestone';
 import { useHistory } from 'react-router-dom';
 import MilestoneEditForm from '../components/milestone/MilestoneEditForm';
 import LabelComponent from '../components/common/LabelComponent';
@@ -44,7 +43,7 @@ const MilestoneEditPage = ({ match }) => {
             func={onClickMilestoneMenu}
           />
         </SelectMenuWrapper>
-        <MilestoneEditForm />
+        <MilestoneEditForm milestoneId={match.params.id} />
       </MilestoneNewPageWrappper>
     </>
   );

--- a/client/src/pages/MilestoneEditPage.jsx
+++ b/client/src/pages/MilestoneEditPage.jsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { getMilestone } from '../lib/axios/milestone';
+import { useHistory } from 'react-router-dom';
 import MilestoneEditForm from '../components/milestone/MilestoneEditForm';
+import LabelComponent from '../components/common/LabelComponent';
+import svg from '../utils/svg';
+import Header from '../components/Header';
 
 const MilestoneNewPageWrappper = styled.div`
   display: flex;
@@ -9,10 +13,37 @@ const MilestoneNewPageWrappper = styled.div`
   margin: 0 auto;
   flex-direction: column;
 `;
+
+const SelectMenuWrapper = styled.div`
+  display: flex;
+  height: 40px;
+  border-bottom: 1px solid black;
+  margin-top: 15px;
+  margin-bottom: 13px;
+  padding-bottom: 10px;
+`;
+
 const MilestoneEditPage = ({ match }) => {
+  const history = useHistory();
+  const onClickMilestoneMenu = () => history.push('/milestones');
+  const onClickLabelMenu = () => history.push('/labels');
+
   return (
     <>
+      <Header />
       <MilestoneNewPageWrappper>
+        <SelectMenuWrapper>
+          <LabelComponent
+            svg={svg['Labels']}
+            title="Labels"
+            func={onClickLabelMenu}
+          />
+          <LabelComponent
+            svg={svg['Milestones']}
+            title="Milestones"
+            func={onClickMilestoneMenu}
+          />
+        </SelectMenuWrapper>
         <MilestoneEditForm />
       </MilestoneNewPageWrappper>
     </>

--- a/client/src/pages/MilestoneEditPage.jsx
+++ b/client/src/pages/MilestoneEditPage.jsx
@@ -1,9 +1,22 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
+import { getMilestone } from '../lib/axios/milestone';
+import MilestoneEditForm from '../components/milestone/MilestoneEditForm';
 
+const MilestoneNewPageWrappper = styled.div`
+  display: flex;
+  width: 80%;
+  margin: 0 auto;
+  flex-direction: column;
+`;
 const MilestoneEditPage = ({ match }) => {
-  console.log(match.params.id);
-  return <></>;
+  return (
+    <>
+      <MilestoneNewPageWrappper>
+        <MilestoneEditForm />
+      </MilestoneNewPageWrappper>
+    </>
+  );
 };
 
 export default MilestoneEditPage;

--- a/client/src/pages/MilestoneNewPage.jsx
+++ b/client/src/pages/MilestoneNewPage.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import MilestoneNewHeader from '../components/milestone/MilestoneNewHeader';
 import Header from '../components/Header';
-import MilestoneForm from '../components/milestone/MilestoneForm';
+import MilestoneCreateForm from '../components/milestone/MilestoneCreateForm';
 
 const MilestoneNewPageWrappper = styled.div`
   display: flex;
@@ -17,7 +17,7 @@ const MilestoneNewPage = () => {
       <Header />
       <MilestoneNewPageWrappper>
         <MilestoneNewHeader />
-        <MilestoneForm />
+        <MilestoneCreateForm />
       </MilestoneNewPageWrappper>
     </>
   );

--- a/client/src/utils/time.js
+++ b/client/src/utils/time.js
@@ -1,7 +1,7 @@
 export const getTimeInfo = (time) => {
   const date = new Date(time);
   const currentDate = new Date();
-  
+
   const timeDiff = currentDate - date; // milliseconds
   const oneSecond = 1000;
   const oneMinute = oneSecond * 60;
@@ -26,8 +26,33 @@ export const getTimeInfo = (time) => {
   const daysDiff = Math.round(timeDiff / oneDay);
   return `${daysDiff} days ago`;
 };
-export const getDueInfo = (time) =>{
-  const monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October","November","December"];
+
+export const getDueInfo = (time) => {
+  const monthNames = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
   const date = new Date(time);
-  return `Due by ${monthNames[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`
-}
+  return `Due by ${
+    monthNames[date.getMonth()]
+  } ${date.getDate()}, ${date.getFullYear()}`;
+};
+
+export const getFormattedDate = ({ date, format }) => {
+  if (format === '-') {
+    const year = date.getFullYear();
+    const month = String(date.getMonth()).padStart(2, 0);
+    const day = String(date.getDate()).padStart(2, 0);
+    return `${year}-${month}-${day}`;
+  }
+};

--- a/server/src/controllers/milestone.js
+++ b/server/src/controllers/milestone.js
@@ -20,4 +20,14 @@ const createMilestone = async (req, res, next) => {
   }
 };
 
-module.exports = { getAllMilestone, createMilestone };
+const getMilestone = async (req, res, next) => {
+  const { id } = req.params;
+  try {
+    const milestone = await Milestone.findByPk(id, { attributes: ['id', 'title', 'description', 'due_date', 'state'] });
+    return res.status(200).json(milestone);
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { getAllMilestone, createMilestone, getMilestone };

--- a/server/src/controllers/milestone.js
+++ b/server/src/controllers/milestone.js
@@ -33,7 +33,6 @@ const getMilestone = async (req, res, next) => {
 const updateMilestone = async (req, res, next) => {
   const { id } = req.params;
   const { title, due_date, description, state } = req.body;
-  console.log('update!');
   await Milestone.update(
     {
       title,
@@ -47,4 +46,18 @@ const updateMilestone = async (req, res, next) => {
   return res.status(200).json(milestone);
 };
 
-module.exports = { getAllMilestone, createMilestone, getMilestone, updateMilestone };
+const patchMilestone = async (req, res, next) => {
+  const { id } = req.params;
+  const { title, due_date, description, state } = req.body;
+  const patchedMilestone = {};
+  if (title) patchedMilestone.title = title;
+  if (due_date) patchedMilestone.due_datet = due_date;
+  if (description) patchedMilestone.description = description;
+  if (state) patchedMilestone.state = state;
+
+  await Milestone.update(patchedMilestone, { where: { id } });
+  const milestone = await Milestone.findByPk(id, { attributes: ['id', 'title', 'description', 'due_date', 'state'] });
+  return res.status(200).json(milestone);
+};
+
+module.exports = { getAllMilestone, createMilestone, getMilestone, updateMilestone, patchMilestone };

--- a/server/src/controllers/milestone.js
+++ b/server/src/controllers/milestone.js
@@ -30,4 +30,21 @@ const getMilestone = async (req, res, next) => {
   }
 };
 
-module.exports = { getAllMilestone, createMilestone, getMilestone };
+const updateMilestone = async (req, res, next) => {
+  const { id } = req.params;
+  const { title, due_date, description, state } = req.body;
+  console.log('update!');
+  await Milestone.update(
+    {
+      title,
+      description,
+      due_date: due_date ? new Date(due_date) : null,
+      state,
+    },
+    { where: { id } },
+  );
+  const milestone = await Milestone.findByPk(id, { attributes: ['id', 'title', 'description', 'due_date', 'state'] });
+  return res.status(200).json(milestone);
+};
+
+module.exports = { getAllMilestone, createMilestone, getMilestone, updateMilestone };

--- a/server/src/routes/milestones.js
+++ b/server/src/routes/milestones.js
@@ -7,5 +7,6 @@ const { isAuth } = require('../middlewares/auth');
 
 router.get('/', isAuth, milestoneController.getAllMilestone);
 router.post('/', isAuth, milestoneController.createMilestone);
+router.get('/:id', isAuth, milestoneController.getMilestone);
 
 module.exports = router;

--- a/server/src/routes/milestones.js
+++ b/server/src/routes/milestones.js
@@ -9,5 +9,6 @@ router.get('/', isAuth, milestoneController.getAllMilestone);
 router.post('/', isAuth, milestoneController.createMilestone);
 router.get('/:id', isAuth, milestoneController.getMilestone);
 router.put('/:id', isAuth, milestoneController.updateMilestone);
+router.patch('/:id', isAuth, milestoneController.patchMilestone);
 
 module.exports = router;

--- a/server/src/routes/milestones.js
+++ b/server/src/routes/milestones.js
@@ -8,5 +8,6 @@ const { isAuth } = require('../middlewares/auth');
 router.get('/', isAuth, milestoneController.getAllMilestone);
 router.post('/', isAuth, milestoneController.createMilestone);
 router.get('/:id', isAuth, milestoneController.getMilestone);
+router.put('/:id', isAuth, milestoneController.updateMilestone);
 
 module.exports = router;


### PR DESCRIPTION
## 관련 이슈
[Epic] 마일스톤을 편집할 수 있다. #150

## 구현/수정 사항
- 백엔드
  - 특정 마일스톤 조회 API
  - 특정 마일스톤 업데이트(put) API
  - 특정 마일스톤 patch API

- 프론트
  - 마일스톤 편집 페이지 UI 구현
  - Save Change 누르면 내용 저장하고 마일스톤 목록페이지로 이동
  - Cancel 누르면 마일스톤 목록 페이지로 이동
  - Open/Reopen 누르면 마일스톤 상태를 변경하고 마일스톤 목록 페이지로 이동
  - GreyButton 공통 컴포넌트 구현

## GreyButton 공통 컴포넌트
![image](https://user-images.githubusercontent.com/26829633/98637852-5e45b980-236c-11eb-8f16-30f10ef3049e.png)


## 마일스톤 편집 페이지
![image](https://user-images.githubusercontent.com/26829633/98637733-2fc7de80-236c-11eb-9777-3b6b5fd0d05a.png)


