### PR TITLE
이슈 생성페이지 side-bar 완성

### DIFF
--- a/client/src/components/issue/MenuContainer.jsx
+++ b/client/src/components/issue/MenuContainer.jsx
@@ -35,11 +35,20 @@ const MenuContainer = () => {
   const history = useHistory();
 
   const onClickFilterButton = () => setFilterMenu(!showFilterMenu);
-  const onClickNewIssue = () => history.push('/issues/new');
+  const onClickNewIssue = (e) => {
+    history.push('/issues/new');
+    e.stopPropagation();
+  };
 
   return (
     <FilterMenuContext.Provider value={{ onClickFilterButton, setFilterMenu }}>
       <Div>
+        <FilterBar
+          onClickFilterButton={onClickFilterButton}
+          setFilterMenu={setFilterMenu}
+          showFilterMenu={showFilterMenu}
+          searchText={searchText}
+        />
         <NavigationContainer />
         <GreenButton text={'New issue'} func={onClickNewIssue} />
       </Div>

--- a/client/src/components/issue/MenuContainer.jsx
+++ b/client/src/components/issue/MenuContainer.jsx
@@ -40,11 +40,6 @@ const MenuContainer = () => {
   return (
     <FilterMenuContext.Provider value={{ onClickFilterButton, setFilterMenu }}>
       <Div>
-        <FilterBar
-          onClickFilterButton={onClickFilterButton}
-          setFilterMenu={setFilterMenu}
-          searchText={searchText}
-        />
         <NavigationContainer />
         <GreenButton text={'New issue'} func={onClickNewIssue} />
       </Div>

--- a/client/src/components/issue/filter/FilterBar.jsx
+++ b/client/src/components/issue/filter/FilterBar.jsx
@@ -27,12 +27,13 @@ const FilterButton = styled.button`
 const FilterBar = ({ onClickFilterButton, setFilterMenu, searchText }) => {
   const filterButtonRef = useRef();
 
-  const clickBody = (e) => {
-    if (filterButtonRef.current && filterButtonRef.current.contains(e.target))
-      return;
-    setFilterMenu(false);
-  };
   useEffect(() => {
+    const clickBody = (e) => {
+      if (filterButtonRef.current && filterButtonRef.current.contains(e.target))
+        return;
+      setFilterMenu(false);
+    };
+
     document.body.addEventListener('click', clickBody);
 
     return () => {

--- a/client/src/components/issue/new/sidebar/Dropdown.jsx
+++ b/client/src/components/issue/new/sidebar/Dropdown.jsx
@@ -5,10 +5,10 @@ const DropdownWrapper = styled.div`
   position: absolute;
   top: 40px;
   border: 1px solid #eaecef;
-  border-radius: 3px;
+  border-radius: 5px;
   box-shadow: 1px 1px 5px 0px #e7e7e7;
   background-color: white;
-  width: 100%;
+  width: 105%;
   z-index: 2;
 
   &.display-block {
@@ -25,15 +25,35 @@ const DropdownWrapper = styled.div`
   }
 `;
 
-const Dropdown = ({ show, add, remove, component, data }) => {
+const DropdownHeader = styled.div`
+  font-size: 12px;
+  font-weight: bold;
+  padding: 5px 0px 5px 8px;
+  border-bottom: 1px solid #eaecef;
+`;
+
+const Dropdown = ({
+  show,
+  setShow,
+  add,
+  remove,
+  set,
+  get,
+  header,
+  component,
+  data,
+}) => {
   const dropdownDisplay = show ? 'display-block' : 'display-none';
   const Component = component;
   const options = data.map((option, index) => (
     <div className="dropdown-option" key={'dropdown' + index}>
       <Component
         option={option}
+        setShow={setShow}
         add={add}
         remove={remove}
+        set={set}
+        get={get}
         padding={5}
         size={18}
       />
@@ -41,7 +61,10 @@ const Dropdown = ({ show, add, remove, component, data }) => {
   ));
 
   return (
-    <DropdownWrapper className={dropdownDisplay}>{options}</DropdownWrapper>
+    <DropdownWrapper className={dropdownDisplay}>
+      <DropdownHeader>{header}</DropdownHeader>
+      {options}
+    </DropdownWrapper>
   );
 };
 

--- a/client/src/components/issue/new/sidebar/LabelOption.jsx
+++ b/client/src/components/issue/new/sidebar/LabelOption.jsx
@@ -5,6 +5,7 @@ import svg from '../../../../utils/svg.js';
 
 const LabelOptionWrapper = styled.div`
   display: flex;
+  justify-content: space-around;
   padding: 5px 0;
   color: #586069;
   font-size: 12px;
@@ -12,6 +13,7 @@ const LabelOptionWrapper = styled.div`
   &:hover {
     background-color: #0366d6;
     color: white;
+    cursor: pointer;
   }
 
   .display-visible {
@@ -21,24 +23,22 @@ const LabelOptionWrapper = styled.div`
     visibility: hidden;
   }
 `;
-const LabelOptionContent = styled.div`
-  flex-grow: 8;
-  max-width: 160px;
+const LabelOptionContent = styled.div``;
+const LabelOptionContentHeader = styled.div`
+  display: flex;
+  width: 187px;
+`;
+const LabelOptionTitle = styled.div``;
+const LabelOptionDescription = styled.div`
+  width: 187px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 `;
-const LabelOptionContentHeader = styled.div`
-  display: flex;
-`;
-const LabelOptionTitle = styled.div``;
-const LabelOptionDescription = styled.div``;
 const CheckWrapper = styled.div`
-  flex-grow: 1;
   text-align: center;
 `;
 const CancelWrapper = styled.div`
-  flex-grow: 1;
   text-align: center;
 `;
 

--- a/client/src/components/issue/new/sidebar/MilestoneOption.jsx
+++ b/client/src/components/issue/new/sidebar/MilestoneOption.jsx
@@ -1,26 +1,94 @@
 import React from 'react';
 import styled from 'styled-components';
+import svg from '../../../../utils/svg.js';
 
 const MilestoneOptionWrapper = styled.div`
   color: #586069;
   font-size: 12px;
-  padding: 5px 0px 5px 15px;
+  padding: 5px 0;
+  display: flex;
   &:hover {
     background-color: #0366d6;
     color: white;
+    cursor: pointer;
   }
-  .title {
-    font-size: 14px;
+  .display-visible {
+    visibility: visible;
+  }
+  .display-hidden {
+    visibility: hidden;
   }
 `;
+const MilestoneContent = styled.div`
+  flex-grow: 8;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+const MilestoneTitle = styled.div`
+  font-size: 15px;
+`;
+const MilestoneDate = styled.div`
+  font-size: 12px;
+`;
+const CheckWrapper = styled.div`
+  flex-grow: 1;
+  text-align: center;
+`;
+const CancelWrapper = styled.div`
+  flex-grow: 1;
+  text-align: center;
+`;
+const months = [
+  'null',
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
 
-const MilestoneOption = ({ option }) => {
-  return (
-    <MilestoneOptionWrapper>
-      <div className="title">{option.title}</div>
-      <div className="description">{option.description}</div>
+const MilestoneOption = ({ option, setShow, set, get }) => {
+  const checkDisplay =
+    (get && get.id) === option.id ? 'display-visible' : 'display-hidden';
+  const getYearMonthDate = (str) =>
+    str ? str.split('T')[0].split('-') : [null, null, null];
+  const [year, month, date] = getYearMonthDate(option.due_date);
+  const handleOnClick = () => {
+    if (get) {
+      if (get.id === option.id) {
+        set([]);
+      } else {
+        set([option]);
+      }
+    } else {
+      set([option]);
+    }
+    setShow(false);
+  };
+
+  return option.state === 'open' ? (
+    <MilestoneOptionWrapper onClick={handleOnClick}>
+      <CheckWrapper className={checkDisplay}>{svg.checkIcon}</CheckWrapper>
+      <MilestoneContent>
+        <MilestoneTitle>{option.title}</MilestoneTitle>
+        <MilestoneDate>
+          {year && month && date
+            ? `Due by ${months[month]} ${date}, ${year}`
+            : '기한미정'}
+        </MilestoneDate>
+      </MilestoneContent>
+      <CancelWrapper className={checkDisplay}>{svg.cancelButton}</CancelWrapper>
     </MilestoneOptionWrapper>
-  );
+  ) : null;
 };
 
 export default MilestoneOption;

--- a/client/src/components/issue/new/sidebar/ProgressBar.jsx
+++ b/client/src/components/issue/new/sidebar/ProgressBar.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const OuterProgressBar = styled.div`
+  width: 100%;
+  background-color: #ebecf0;
+  border-radius: 10px;
+  margin: 5px 0;
+`;
+const InnerProgressBar = styled.div`
+  width: ${(props) => props.width}%;
+  height: 10px;
+  background-color: #5fba5d;
+  border-radius: 10px;
+`;
+
+const ProgressBar = ({ width }) => {
+  return (
+    <OuterProgressBar>
+      <InnerProgressBar width={width} />
+    </OuterProgressBar>
+  );
+};
+
+export default ProgressBar;

--- a/client/src/components/issue/new/sidebar/SelectedMilestone.jsx
+++ b/client/src/components/issue/new/sidebar/SelectedMilestone.jsx
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react';
+import styled from 'styled-components';
+import ProgressBar from './ProgressBar';
+import { IssueOptionContext } from '../../../../pages/issue-new/IssueNewPage';
+
+const SelectedMilestoneWrapper = styled.div``;
+const MilestoneTitleWrapper = styled.div`
+  font-size: 12px;
+`;
+
+const SelectedMilestone = ({ milestone }) => {
+  const { state } = useContext(IssueOptionContext);
+  const issues = state.issues.filter(
+    (issue) => issue.milestone && issue.milestone.id === milestone.id,
+  );
+  const total = issues.length;
+  const closed = issues.filter((issue) => issue.state === 'closed').length;
+  const progress = total === 0 ? 0 : Math.floor((closed / total) * 100);
+  return (
+    <SelectedMilestoneWrapper>
+      <ProgressBar width={progress} />
+      <MilestoneTitleWrapper>{milestone.title}</MilestoneTitleWrapper>
+    </SelectedMilestoneWrapper>
+  );
+};
+
+export default SelectedMilestone;

--- a/client/src/components/issue/new/sidebar/Sidebar.jsx
+++ b/client/src/components/issue/new/sidebar/Sidebar.jsx
@@ -23,6 +23,7 @@ const Sidebar = () => {
     {
       title: 'Assignees',
       type: ADD_ASSIGNEES,
+      header: 'Assign up to 10 people to this issue',
       stateMsg: 'No one',
       component: AssigneeOption,
       data: state.users,
@@ -31,6 +32,7 @@ const Sidebar = () => {
     {
       title: 'Labels',
       type: ADD_LABELS,
+      header: 'Apply labels to this issue',
       stateMsg: 'None yet',
       component: LabelOption,
       data: state.labels,
@@ -39,6 +41,7 @@ const Sidebar = () => {
     {
       title: 'Milestone',
       type: SET_MILESTONE,
+      header: 'Set milestone',
       stateMsg: 'No milestone',
       component: MilestoneOption,
       data: state.milestones,
@@ -52,6 +55,7 @@ const Sidebar = () => {
         key={'sidebar-item' + index}
         title={item.title}
         type={item.type}
+        header={item.header}
         stateMsg={item.stateMsg}
         component={item.component}
         data={item.data}

--- a/client/src/components/issue/new/sidebar/SidebarItem.jsx
+++ b/client/src/components/issue/new/sidebar/SidebarItem.jsx
@@ -40,7 +40,9 @@ const SidebarItem = ({ title, type, stateMsg, component, data }) => {
     };
     document.body.addEventListener('click', clickBody);
 
-    return document.body.removeEventListener('click', clickBody);
+    return () => {
+      document.body.removeEventListener('click', clickBody);
+    };
   }, []);
 
   useEffect(() => {

--- a/client/src/components/issue/new/sidebar/SidebarItem.jsx
+++ b/client/src/components/issue/new/sidebar/SidebarItem.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useContext } from 'react';
 import { IssueOptionContext } from '../../../../pages/issue-new/IssueNewPage';
 import SelectedLabel from './SelectedLabel';
+import SelectedMilestone from './SelectedMilestone';
 import styled from 'styled-components';
 import Heading from './Heading';
 import Dropdown from './Dropdown';
@@ -19,7 +20,7 @@ const StateMsg = styled.div`
   font-size: 12px;
 `;
 
-const SidebarItem = ({ title, type, stateMsg, component, data }) => {
+const SidebarItem = ({ title, type, header, stateMsg, component, data }) => {
   const ref = useRef();
   const [show, setShow] = useState(false);
   const [checked, setChecked] = useState([]);
@@ -73,22 +74,26 @@ const SidebarItem = ({ title, type, stateMsg, component, data }) => {
           <SelectedLabel key={'addedLabel' + index} label={addedItem} />
         ));
       case 'Milestone':
-        return;
+        return <SelectedMilestone milestone={checked[0]} />;
     }
   };
 
   return (
     <SidebarItemWrapper ref={ref}>
       <Heading title={title} onClick={handleOnClick} show={show} />
-      {checked && checked.length > 0 ? (
+      {!show && checked && checked.length > 0 ? (
         renderedAddedList(Component, title)
       ) : (
         <StateMsg>{stateMsg}</StateMsg>
       )}
       <Dropdown
         show={show}
+        setShow={setShow}
         add={addChecked}
         remove={removeChecked}
+        set={setChecked}
+        get={checked[0]}
+        header={header}
         component={component}
         data={data}
       />

--- a/client/src/pages/issue-new/IssueNewPage.jsx
+++ b/client/src/pages/issue-new/IssueNewPage.jsx
@@ -6,6 +6,7 @@ import IssueNewContent from '../../components/issue/new/IssueNewContent';
 import reducer from './reducer.js';
 import Sidebar from '../../components/issue/new/sidebar/Sidebar';
 import ProfileImage from '../../components/common/ProfileImage';
+import { getAllIssues } from '../../lib/axios/issue';
 import { getAllLabels } from '../../lib/axios/label';
 import { getAllMilestones } from '../../lib/axios/milestone';
 import { getAllUsers } from '../../lib/axios/user';
@@ -30,6 +31,7 @@ export const IssueOptionContext = React.createContext();
 
 const initialState = {
   users: [],
+  issues: [],
   labels: [],
   milestones: [],
   addedAssignees: [],
@@ -42,14 +44,15 @@ const IssueListNewPage = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(async () => {
-    const [labels, milestones, users] = await Promise.all([
+    const [issues, labels, milestones, users] = await Promise.all([
+      getAllIssues(),
       getAllLabels(),
       getAllMilestones(),
       getAllUsers(),
     ]);
     dispatch({
       type: INIT_DATA,
-      data: { labels, milestones, users },
+      data: { issues, labels, milestones, users },
     });
   }, []);
 


### PR DESCRIPTION
## 관련 이슈
- 이슈 생성 페이지에서 마일스톤 목록 UI 구현 #39
- 이슈 생성 페이지에서 마일스톤 등록 이벤트 구현 #98

## 구현/수정 내용
- 마일스톤을 클릭하면 해당 마일스톤으로 지정되도록 추가
- progress bar 구현
- css 수정 및 ui 개선작업

## 화면
![image](https://user-images.githubusercontent.com/38288479/98669389-a8db2c00-2394-11eb-87b7-d2a52eb77b05.png)
![image](https://user-images.githubusercontent.com/38288479/98669407-aed10d00-2394-11eb-8671-a614a8c27596.png)
![image](https://user-images.githubusercontent.com/38288479/98669422-b7294800-2394-11eb-9357-ebd2dd7d6778.png)
![image](https://user-images.githubusercontent.com/38288479/98669476-c60ffa80-2394-11eb-9770-24a32f852965.png)
