### PR TITLE
[feature] : 마일스톤 목록 페이지 구현 및 라우팅

### DIFF
--- a/client/src/components/milestone/MilestoneCreateForm.jsx
+++ b/client/src/components/milestone/MilestoneCreateForm.jsx
@@ -37,6 +37,7 @@ const MilestoneCreateForm = () => {
     }
     createMilestone({ title, due_date: date, description });
     history.push('/milestones');
+    location.reload();
   };
 
   return (

--- a/client/src/components/milestone/MilestoneList.jsx
+++ b/client/src/components/milestone/MilestoneList.jsx
@@ -13,10 +13,10 @@ const MilestoneListWrapper = styled.div`
 `;
 
 const MilestoneList = ({milestone, milestoneTitle}) =>{
-   return (
+  return (
        <MilestoneListWrapper>
             <MilestoneListLeft milestone={milestone}/>
-            <MilestoneListRight milestoneId={milestone.id}milestone={milestone} milestoneTitle={milestoneTitle}/>
+            <MilestoneListRight milestone={milestone}/>
        </MilestoneListWrapper>
    );
 }

--- a/client/src/components/milestone/MilestoneModal.jsx
+++ b/client/src/components/milestone/MilestoneModal.jsx
@@ -2,8 +2,11 @@ import React, {useContext, useEffect}from 'react';
 import {MilestoneContext} from '../../pages/milestone-list/MilestonePage';
 import styled from 'styled-components';
 import {DELETE_MILESTONE} from '../../pages/milestone-list/reducer';
-
+import {deleteMilestone} from '../../lib/axios/milestone';
+import {INIT_DATA} from '../../pages/milestone-list/reducer';
+import { Redirect } from 'react-router-dom';
 const MilestoneModalWrapper=styled.div`
+  
   display:${(props)=>props.display};
   position:fixed;
   width:100%;
@@ -21,6 +24,20 @@ const MilestoneModalContent =styled.div`
   border: 1px solid #888; 
   width: 30%; /* Could be more or less, depending on screen size */
   border-radius:5px; 
+  box-shadow: 2px 2px 2px 1px rgba(0, 0, 0, 0.2);
+  opacity: 1;
+  animation-name: fadein;
+  animation-iteration-count: 1;
+  animation-timing-function: ease-in;
+  animation-duration: 0.2s;
+  @keyframes fadein {
+   from {
+       opacity:0;
+   }
+   to {
+       opacity:1;
+   }
+}
 `;
 const MilestoneModalTitle = styled.div`
   font-weight:bold;
@@ -57,7 +74,7 @@ const MilestonModalParagraph = styled.p`
  padding-top:10px;
 `;
 const MilestoneModalFooter = styled.div`
-  border-top:1px solid #E1E4E8;
+  border-top:1px solid #888;
   width:98%;
   display:flex;
   justify-content:center;
@@ -83,13 +100,20 @@ const MilestoneDeleteButton = styled.button`
 `;
 const MilestoneModal = ({display, milestoneId}) =>{
     const {state, dispatch} = useContext(MilestoneContext);
+    const {milestones} = state;
     const closeHandler = () =>{
        let display = state.display==='block'?'none':'block';
        display = state.display==='none'?'block':'none';
-       dispatch({type:DELETE_MILESTONE, display:display});
+       dispatch({type:DELETE_MILESTONE, display:display, milestoneId:milestoneId});
     }
-    const deleteHandler = () =>{
-       console.log(milestoneId);
+    const deleteHandler = async () =>{
+       await deleteMilestone(milestoneId);
+       dispatch( {type: INIT_DATA,
+         milestones: milestones,
+         milestoneList:milestones.filter(milestone=>milestone.state==='open'),
+         issues:[],
+         display:'none'});
+         location.reload();
     }
     return(
       <MilestoneModalWrapper display={display}>

--- a/client/src/components/milestone/MilestoneNav.jsx
+++ b/client/src/components/milestone/MilestoneNav.jsx
@@ -22,13 +22,14 @@ const OpenDiv = styled.div`
  margin-left:5px;
  padding-left:10px;
  cursor:pointer;
- font-weight:${(props)=>props.fontWeight==='bold'?'bold':'normal'};
+ font-weight:bold;
 `
 const CloseDiv = styled.div`
  margin-left:5px;
  padding-left:10px;
  cursor:pointer;
 `;
+
 const MilestoneNav = ({milestones}) =>{
   const openMilestone = milestones.filter(milestone=> milestone.state==="open").length;
   const closeMilestone = milestones.filter(milestone=>milestone.state==="close").length;

--- a/client/src/lib/axios/milestone.js
+++ b/client/src/lib/axios/milestone.js
@@ -1,4 +1,4 @@
-import { getData, postData, putData, patchData } from './request';
+import { getData, postData, putData, patchData, deleteData} from './request';
 
 const url = {
   GET_ALL_MILESTONES: 'milestones',
@@ -6,6 +6,7 @@ const url = {
   GET_MILESTONE: 'milestones/',
   UPDATE_MILESTONE: 'milestones/',
   PATCH_MILESTONE: 'milestones/',
+  DELETE_MILESTONE:'milestones/'
 };
 
 export const getAllMilestones = async () => {
@@ -32,3 +33,8 @@ export const patchMilestone = async (id, body) => {
   const milestone = await patchData(`${url.GET_MILESTONE}${id}`, body);
   return milestone;
 };
+
+export const deleteMilestone = async (id) =>{
+  const milestone = await deleteData(`${url.DELETE_MILESTONE}${id}`);
+  return milestone;
+}

--- a/client/src/pages/milestone-list/MilestonePage.jsx
+++ b/client/src/pages/milestone-list/MilestonePage.jsx
@@ -3,10 +3,11 @@ import Header from '../../components/Header';
 import MilestoneHeader  from '../../components/milestone/MilestoneHeader'
 import MilestoneNav from '../../components/milestone/MilestoneNav';
 import MilestoneList from '../../components/milestone/MilestoneList';
+import MilestoneModal from '../../components/milestone/MilestoneModal';
 import reducer from './reducer';
 import {getAllMilestones} from '../../lib/axios/milestone';
 import {getAllIssues} from '../../lib/axios/issue';
-import {INIT_DATA} from '../../pages/milestone-list/reducer';
+import {INIT_DATA} from './reducer';
 
 export const MilestoneContext = React.createContext();
 
@@ -44,6 +45,7 @@ const MilestonePage =  () =>{
        {state.milestoneList.map((milestone, index)=>(
          <MilestoneList key={index} milestone={milestone} milestoneTitle={milestone.title}/>)
         )}
+      <MilestoneModal display={state.display} milestoneId={state.milestoneId}></MilestoneModal>
       </MilestoneContext.Provider>
     );
 }

--- a/client/src/pages/milestone-list/reducer.js
+++ b/client/src/pages/milestone-list/reducer.js
@@ -31,6 +31,7 @@ const reducer = (state, action) =>{
         return{
           ...state,
           display:action.display,
+          milestoneId:action.milestoneId,
         }
       }   
   }


### PR DESCRIPTION
## 관련 이슈
- 마일스톤 목록을 조회할 수 있다. #77  

## 구현/수정 사항
 - 마일스톤 상세 페이지 라우팅
 - 마일스톤 삭제 버튼 클릭시 모달 창 띄우기 구현하였습니다.
 - axios를 이용해서 api를 요청하여 삭제되도록 구현하였습니다.
 - 마일스톤 open, close에 따라서 reopen, close를 구현하였습니다.

## 결과
<img width="1385" alt="스크린샷 2020-11-11 오후 5 44 51" src="https://user-images.githubusercontent.com/22065725/98789477-af75ac00-2445-11eb-945b-df161abb3108.png">
<img width="1321" alt="스크린샷 2020-11-11 오후 5 44 57" src="https://user-images.githubusercontent.com/22065725/98789485-b2709c80-2445-11eb-8a4a-24591d019cc9.png">
<img width="1385" alt="스크린샷 2020-11-11 오후 5 45 02" src="https://user-images.githubusercontent.com/22065725/98789489-b3093300-2445-11eb-993e-f1c46f4d14dd.png">


