### PR TITLE
이슈 상세 페이지 사이드바 구현(클릭 시 목록 나오게 구현, 조회 api 연동)

### DIFF
--- a/client/src/components/common/sidebar/Assignee.jsx
+++ b/client/src/components/common/sidebar/Assignee.jsx
@@ -7,19 +7,15 @@ const AssignWrapper = styled.div`
    width:100%;
    height:30px;
    border-bottom : 1px solid #eaecef;
+   cursor:pointer;
 `;
-const Profile = styled.img.attrs({
-    src: props => props.profile
-})`
-border-radius:5px;
-`;
+
 const Assignee = ({snsId, profile}) =>{
   console.log(profile);
   return(
      <AssignWrapper>
          <ProfileImage image={profile} size='15'></ProfileImage>
          {snsId}
-    
      </AssignWrapper>
   );
 }

--- a/client/src/components/common/sidebar/Assignee.jsx
+++ b/client/src/components/common/sidebar/Assignee.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+import ProfileImage from '../../common/ProfileImage';
+const AssignWrapper = styled.div`
+   display:flex;
+   justify-content:center;
+   width:100%;
+   height:30px;
+   border-bottom : 1px solid #eaecef;
+`;
+const Profile = styled.img.attrs({
+    src: props => props.profile
+})`
+border-radius:5px;
+`;
+const Assignee = ({snsId, profile}) =>{
+  console.log(profile);
+  return(
+     <AssignWrapper>
+         <ProfileImage image={profile} size='15'></ProfileImage>
+         {snsId}
+    
+     </AssignWrapper>
+  );
+}
+export default Assignee;

--- a/client/src/components/common/sidebar/Label.jsx
+++ b/client/src/components/common/sidebar/Label.jsx
@@ -2,16 +2,20 @@ import React from 'react';
 import styled from 'styled-components'; 
 import SmallLabel from '../SmallLabel';
 const LabelWrapper = styled.div`
-
+  border-bottom: 1px solid #eaecef;
+  cursor:pointer;
 `;
 const LabelOptionContent = styled.div`
   flex-basis: 80%;
   display: flex;
-  flex-direction: column;
+  justify-content:center;
   width: 100%;
 `;
 const LabelOptionTitle = styled.div``;
-const LabelOptionDescription = styled.div``;
+const LabelOptionDescription = styled.div`
+  display:flex;
+  justify-content:center;
+`;
 const Label = ({color, title, description}) =>{
   return (
         <LabelWrapper>

--- a/client/src/components/common/sidebar/Label.jsx
+++ b/client/src/components/common/sidebar/Label.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components'; 
+import SmallLabel from '../SmallLabel';
+const LabelWrapper = styled.div`
+
+`;
+const LabelOptionContent = styled.div`
+  flex-basis: 80%;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+const LabelOptionTitle = styled.div``;
+const LabelOptionDescription = styled.div``;
+const Label = ({color, title, description}) =>{
+  return (
+        <LabelWrapper>
+          <LabelOptionContent>
+             <SmallLabel color={color} size={14} marginTop={2} ></SmallLabel>
+             <LabelOptionTitle>{title}</LabelOptionTitle>
+          </LabelOptionContent> 
+          <LabelOptionDescription>{description}</LabelOptionDescription>
+        </LabelWrapper>
+  );
+}
+export default Label;

--- a/client/src/components/common/sidebar/Milestone.jsx
+++ b/client/src/components/common/sidebar/Milestone.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Milestone = () =>{
+  return(
+    <>
+    </>
+  );
+}
+export default Milestone;

--- a/client/src/components/common/sidebar/Milestone.jsx
+++ b/client/src/components/common/sidebar/Milestone.jsx
@@ -1,10 +1,25 @@
 import React from 'react';
 import styled from 'styled-components';
-
-const Milestone = () =>{
+import {getDueInfo} from '../../../utils/time';
+const MilestoneWrapper = styled.div`
+ cursor:pointer;
+ border-bottom: 1px solid #eaecef;
+ .dueDate{
+     margin-left:10px;
+ }
+`;
+const MilestoneContent = styled.div`
+  display:flex;
+  justify-content:center;
+`;
+const Milestone = ({title, dueDate}) =>{
   return(
-    <>
-    </>
+    <MilestoneWrapper>
+       <MilestoneContent>
+           <div>{title}</div>
+           <div className='dueDate'>{getDueInfo(dueDate)}</div>
+       </MilestoneContent>
+    </MilestoneWrapper>
   );
 }
 export default Milestone;

--- a/client/src/components/common/sidebar/Sidebar.jsx
+++ b/client/src/components/common/sidebar/Sidebar.jsx
@@ -1,0 +1,43 @@
+import React, {useState} from 'react';
+import styled from 'styled-components';
+import SidebarItem from './SidebarItem';
+const SidebarWrapper = styled.div`
+  flex-basis : 23%;
+  width:100%;
+`;
+
+const Sidebar = () =>{
+
+  const defaultItems = [
+      {
+          title:'Assignees',
+          header:'Assign up to 10 people to this issue',
+          stateMsg: 'No one',
+      },
+      {
+          title:'Labels',
+          header:'Apply labels to this issue',
+          stateMsg: 'None yet',
+      },
+      {
+          title:'Milestone',
+          header:'Set milestone',
+          stateMsg: 'No milestone',
+      }
+  ];
+  const SidebarItems = defaultItems.map((item, index)=>{
+    return(
+       <>
+        <SidebarItem
+          key={'sidebar-item'+index}
+          title={item.title}
+          header={item.header}
+          stateMsg={item.stateMsg}
+        />
+       </>
+    );
+  });
+  return <SidebarWrapper>{SidebarItems}</SidebarWrapper>
+}
+
+export default Sidebar;

--- a/client/src/components/common/sidebar/Sidebar.jsx
+++ b/client/src/components/common/sidebar/Sidebar.jsx
@@ -1,28 +1,32 @@
-import React, {useState} from 'react';
+import React, {useContext} from 'react';
 import styled from 'styled-components';
 import SidebarItem from './SidebarItem';
+import {IssueContext} from '../../../pages/IssueDetailPage'; 
 const SidebarWrapper = styled.div`
   flex-basis : 23%;
   width:100%;
 `;
 
 const Sidebar = () =>{
-
+  const {assignee, setAssignee, label, setLabel, milestone, setMilestone} = useContext(IssueContext);
   const defaultItems = [
       {
           title:'Assignees',
           header:'Assign up to 10 people to this issue',
           stateMsg: 'No one',
+          component: assignee,
       },
       {
           title:'Labels',
           header:'Apply labels to this issue',
           stateMsg: 'None yet',
+          component: label,
       },
       {
           title:'Milestone',
           header:'Set milestone',
           stateMsg: 'No milestone',
+          component:milestone
       }
   ];
   const SidebarItems = defaultItems.map((item, index)=>{
@@ -33,6 +37,7 @@ const Sidebar = () =>{
           title={item.title}
           header={item.header}
           stateMsg={item.stateMsg}
+          component={item.component}
         />
        </>
     );

--- a/client/src/components/common/sidebar/SidebarItem.jsx
+++ b/client/src/components/common/sidebar/SidebarItem.jsx
@@ -12,7 +12,7 @@ const SidebarItemWrapper = styled.div`
 const SidebarStateMsg = styled.div`
   margin-top:10px;
 `;
-const SidebarItem = ({title, header, stateMsg}) =>{
+const SidebarItem = ({title, header, stateMsg, component}) =>{
    const [stateMessage, setStateMsg] = useState(stateMsg);
    const [show, setShow] = useState(false);
 
@@ -24,7 +24,7 @@ const SidebarItem = ({title, header, stateMsg}) =>{
         <SidebarItemTitle title={title} onClick={handleOnClick}></SidebarItemTitle>
         {!show? 
          <SidebarStateMsg>{stateMessage}</SidebarStateMsg>
-        : <SidebarItemModal header={header}/>
+        : <SidebarItemModal title={title} header={header} component={component}/>
         }
     </SidebarItemWrapper>
    );

--- a/client/src/components/common/sidebar/SidebarItem.jsx
+++ b/client/src/components/common/sidebar/SidebarItem.jsx
@@ -1,0 +1,33 @@
+import React, {useState} from 'react';
+import styled from 'styled-components';
+import SidebarItemTitle from './SidebarItemTitle';
+import SidebarItemModal from './SidebarItemModal';
+const SidebarItemWrapper = styled.div`
+  position:relative;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  width:100%;
+  border-bottom:1px solid #eaecef;
+`;
+const SidebarStateMsg = styled.div`
+  margin-top:10px;
+`;
+const SidebarItem = ({title, header, stateMsg}) =>{
+   const [stateMessage, setStateMsg] = useState(stateMsg);
+   const [show, setShow] = useState(false);
+
+   const handleOnClick = () =>{
+       setShow(!show);
+   }
+   return (
+    <SidebarItemWrapper>
+        <SidebarItemTitle title={title} onClick={handleOnClick}></SidebarItemTitle>
+        {!show? 
+         <SidebarStateMsg>{stateMessage}</SidebarStateMsg>
+        : <SidebarItemModal header={header}/>
+        }
+    </SidebarItemWrapper>
+   );
+};
+
+export default SidebarItem;

--- a/client/src/components/common/sidebar/SidebarItemModal.jsx
+++ b/client/src/components/common/sidebar/SidebarItemModal.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import Assignee from './Assignee';
+import Label from './Label';
+import Milestone from './milestone';
 const SidebarItemModalWrapper = styled.div`
   position:absolute;
   width:100%;
@@ -15,6 +17,7 @@ const ModalTitle = styled.div`
 `;
 
 const SidebarItemModal = ({title, header, component}) =>{
+  console.log(component);
   return(
     <SidebarItemModalWrapper>
         <ModalTitle>{header}</ModalTitle>
@@ -22,7 +25,14 @@ const SidebarItemModal = ({title, header, component}) =>{
         component.map((item)=>(
             <Assignee snsId={item.sns_id} profile={item.profile_image}></Assignee>
         )):null}
-       
+       {title==='Labels'?
+        component.map((item)=>(
+            <Label color={item.color} title={item.title} description={item.description}></Label>
+        )):null}
+        {title==='Milestone'?
+         component.map((item)=>(
+            <Milestone></Milestone>
+         )):null} 
     </SidebarItemModalWrapper>
   );
 }

--- a/client/src/components/common/sidebar/SidebarItemModal.jsx
+++ b/client/src/components/common/sidebar/SidebarItemModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import Assignee from './Assignee';
 const SidebarItemModalWrapper = styled.div`
   position:absolute;
   width:100%;
@@ -12,10 +13,16 @@ const ModalTitle = styled.div`
   margin-top:10px;
   border-bottom : 1px solid #eaecef;
 `;
-const SidebarItemModal = ({header}) =>{
+
+const SidebarItemModal = ({title, header, component}) =>{
   return(
     <SidebarItemModalWrapper>
         <ModalTitle>{header}</ModalTitle>
+        {title==='Assignees'? 
+        component.map((item)=>(
+            <Assignee snsId={item.sns_id} profile={item.profile_image}></Assignee>
+        )):null}
+       
     </SidebarItemModalWrapper>
   );
 }

--- a/client/src/components/common/sidebar/SidebarItemModal.jsx
+++ b/client/src/components/common/sidebar/SidebarItemModal.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import Assignee from './Assignee';
 import Label from './Label';
 import Milestone from './milestone';
+import {getDueInfo} from '../../../utils/time';
 const SidebarItemModalWrapper = styled.div`
   position:absolute;
   width:100%;
@@ -31,7 +32,7 @@ const SidebarItemModal = ({title, header, component}) =>{
         )):null}
         {title==='Milestone'?
          component.map((item)=>(
-            <Milestone></Milestone>
+            <Milestone title={item.title} dueDate={item.due_date}></Milestone>
          )):null} 
     </SidebarItemModalWrapper>
   );

--- a/client/src/components/common/sidebar/SidebarItemModal.jsx
+++ b/client/src/components/common/sidebar/SidebarItemModal.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styled from 'styled-components';
+const SidebarItemModalWrapper = styled.div`
+  position:absolute;
+  width:100%;
+  height:300px;
+  background-color:#fff;
+  z-index:2;
+  border:1px solid #e4e6e9;
+`;
+const ModalTitle = styled.div`
+  margin-top:10px;
+  border-bottom : 1px solid #eaecef;
+`;
+const SidebarItemModal = ({header}) =>{
+  return(
+    <SidebarItemModalWrapper>
+        <ModalTitle>{header}</ModalTitle>
+    </SidebarItemModalWrapper>
+  );
+}
+
+export default SidebarItemModal;

--- a/client/src/components/common/sidebar/SidebarItemTitle.jsx
+++ b/client/src/components/common/sidebar/SidebarItemTitle.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+import { getAllLabels } from '../../../lib/axios/label';
+import svg from '../../../utils/svg';
+const COLORS = {
+    TEXT: '#586069',
+    SVG: '#959da5',
+    HOVER: '#0366d6',
+  };
+const SidebarItemTitleWrapper = styled.div`
+  display:flex;
+  justify-content:space-between;
+  cursor:pointer;
+  &:hover{
+      color:${COLORS.HOVER};
+  }
+`;
+const SidebarItemTitle = ({title, onClick}) =>{
+    return(
+     <SidebarItemTitleWrapper onClick={onClick}>
+        {title} {svg['SidebarIcon']}
+     </SidebarItemTitleWrapper>
+    );
+};
+
+export default SidebarItemTitle;

--- a/client/src/components/common/sidebar/SidebarItemTitle.jsx
+++ b/client/src/components/common/sidebar/SidebarItemTitle.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { getAllLabels } from '../../../lib/axios/label';
 import svg from '../../../utils/svg';
 const COLORS = {
     TEXT: '#586069',

--- a/client/src/components/issue/detail/SidebarContainer.jsx
+++ b/client/src/components/issue/detail/SidebarContainer.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-
+import Sidebar from '../../common/sidebar/Sidebar';
 const Container = styled.div`
   display: flex;
   width: 29%;
@@ -10,7 +10,11 @@ const Container = styled.div`
 `;
 
 const SideBarContainer = () => {
-  return <Container></Container>;
+  return (
+   <Container>
+      <Sidebar></Sidebar>
+   </Container>
+  );
 };
 
 export default SideBarContainer;

--- a/client/src/components/milestone/MilestoneNav.jsx
+++ b/client/src/components/milestone/MilestoneNav.jsx
@@ -10,7 +10,7 @@ width:80%;
 height:50px;
 margin:0 auto;
 margin-top:40px;
-background-color:#F6F8F4;
+background-color:#E6E6E6;
 border-top-left-radius:5px;
 border-top-right-radius:5px;
 border:1px solid #E1E4E8;

--- a/client/src/pages/IssueDetailPage.jsx
+++ b/client/src/pages/IssueDetailPage.jsx
@@ -3,6 +3,9 @@ import styled from 'styled-components';
 import Header from '../components/Header';
 import IssueDetailPageHeader from '../components/issue/detail/IssueDetailPageHeader';
 import { getIssue } from '../lib/axios/issue';
+import {getAllLabels} from '../lib/axios/label';
+import {getAllMilestones} from '../lib/axios/milestone';
+import {getAllUsers} from '../lib/axios/user';
 import Spinner from '../components/common/Spinner';
 import IssueContainer from '../components/issue/detail/IssueContainer';
 import SidebarContainer from '../components/issue/detail/SidebarContainer';
@@ -24,9 +27,14 @@ export const IssueContext = React.createContext();
 const IssueDetailPage = ({ match }) => {
   const issueId = match.params.id;
   const [issue, setIssue] = useState(null);
-
+  const [assignee, setAssignee] = useState(null);
+  const [milestone, setMilestone] = useState(null);
+  const [label, setLabel] = useState(null);
   useEffect(async () => {
     setIssue(await getIssue(issueId));
+    setAssignee(await getAllUsers());
+    setLabel(await getAllLabels());
+    setMilestone(await getAllMilestones());
   }, []);
 
   if (!issue) {
@@ -36,7 +44,7 @@ const IssueDetailPage = ({ match }) => {
   return (
     <>
       <Header />
-      <IssueContext.Provider value={{ issue, setIssue }}>
+      <IssueContext.Provider value={{ issue, setIssue, assignee, setAssignee, label, setLabel, milestone, setMilestone}}>
         <IssueDetailPageWrapper>
           <IssueDetailPageHeader />
           <ContentWrapper>


### PR DESCRIPTION
## 관련 이슈
- 이슈 생성시 마일스톤 목록을 볼 수 있다.  #38  

## 구현/수정 내용
- 클릭 시 목록 나오게 구현하였습니다.
- api를 이용해서 목록을 가져오도록 구현하였습니다.

## 결과 
<img width="1359" alt="스크린샷 2020-11-12 오전 4 06 38" src="https://user-images.githubusercontent.com/22065725/98853527-9ba96480-249c-11eb-9910-673281d225d1.png">
<img width="1376" alt="스크린샷 2020-11-12 오전 4 07 07" src="https://user-images.githubusercontent.com/22065725/98853534-9ea45500-249c-11eb-9d4e-5283bcaf5943.png">

